### PR TITLE
Add replayer kill-switch

### DIFF
--- a/pkg/api/replay.go
+++ b/pkg/api/replay.go
@@ -65,8 +65,14 @@ func (h *ReplayHandler) getService(w http.ResponseWriter, r *http.Request) db.DB
 		serviceName = ""
 	}
 
-	if h.router.GetServices()[serviceName] == nil {
+	svc := h.router.GetServices()[serviceName]
+	if svc == nil {
 		http.Error(w, "Service not found", http.StatusNotFound)
+		return nil
+	}
+
+	if svc.Config != nil && !svc.Config.ReplayEnabled() {
+		http.Error(w, "Replay disabled for this service", http.StatusNotFound)
 		return nil
 	}
 

--- a/pkg/api/replay_test.go
+++ b/pkg/api/replay_test.go
@@ -331,6 +331,31 @@ func TestReplayHandler_clear(t *testing.T) {
 	})
 }
 
+func TestReplayHandler_serviceReplayDisabled(t *testing.T) {
+	t.Run("Returns 404 when service has replay disabled", func(t *testing.T) {
+		router := newTestRouter(t)
+
+		disabled := false
+		svcCfg := config.NewServiceConfig()
+		svcCfg.Replay = &config.ReplayConfig{Enabled: &disabled}
+
+		service := &mockService{
+			name:   "no-replay",
+			config: svcCfg,
+			routes: func(r chi.Router) {},
+		}
+		registerTestService(router, service)
+		_ = CreateReplayRoutes(router)
+
+		req := httptest.NewRequest(http.MethodGet, "/.replay?service=no-replay", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Contains(t, w.Body.String(), "Replay disabled")
+	})
+}
+
 func TestReplayHandler_rootService(t *testing.T) {
 	t.Run("Returns recordings for root service via .root name", func(t *testing.T) {
 		router := newTestRouter(t)

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -178,14 +178,19 @@ func (r *Router) register(
 		}
 	}
 
-	// Inject the app-level default replay duration so a service's replay.duration
-	// overrides it and header-only replay still records with the app default.
+	// Inject the app-level default replay duration (a service's replay.duration
+	// overrides it) and push down an app-level disable so ROUTER_REPLAY_ENABLED=false
+	// stops recording, not just the explorer URL (a service's replay.enabled overrides).
 	if r.config.Replay != nil {
 		if cfg.Replay == nil {
 			cfg.Replay = &config.ReplayConfig{}
 		}
 		if cfg.Replay.Duration == 0 {
 			cfg.Replay.Duration = r.config.Replay.Duration
+		}
+		if r.config.Replay.Enabled != nil && !*r.config.Replay.Enabled && cfg.Replay.Enabled == nil {
+			disabled := false
+			cfg.Replay.Enabled = &disabled
 		}
 	}
 

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -1051,6 +1051,36 @@ cache:
 	})
 }
 
+func TestRouter_RegisterService_ReplayDisablePushdown(t *testing.T) {
+	t.Run("app-level disable propagates to service without own setting", func(t *testing.T) {
+		router := newTestRouter(t)
+		disabled := false
+		router.config.Replay.Enabled = &disabled
+
+		svcCfg := config.NewServiceConfig()
+		svcCfg.Name = "svc"
+		service := &mockService{name: "svc", config: svcCfg, routes: func(r chi.Router) {}}
+		registerTestService(router, service)
+
+		assert.False(t, router.GetServices()["svc"].Config.ReplayEnabled())
+	})
+
+	t.Run("service opt-in overrides app-level disable", func(t *testing.T) {
+		router := newTestRouter(t)
+		disabled := false
+		router.config.Replay.Enabled = &disabled
+
+		enabled := true
+		svcCfg := config.NewServiceConfig()
+		svcCfg.Name = "svc"
+		svcCfg.Replay = &config.ReplayConfig{Enabled: &enabled}
+		service := &mockService{name: "svc", config: svcCfg, routes: func(r chi.Router) {}}
+		registerTestService(router, service)
+
+		assert.True(t, router.GetServices()["svc"].Config.ReplayEnabled())
+	})
+}
+
 func TestLoadAppConfig(t *testing.T) {
 	t.Run("loads config from file", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -66,7 +66,8 @@ func NewDefaultAppReplayConfig() *AppReplayConfig {
 
 // AppReplayConfig configures replay recording and the replay explorer at the
 // application level. Duration is the default replay-recording TTL; a service's
-// replay.duration overrides it. Enabled gates the explorer URL (like history).
+// replay.duration overrides it. Enabled=false stops replay recording and serving
+// for all services and hides the explorer URL; a service's replay.enabled overrides.
 type AppReplayConfig struct {
 	Enabled  *bool         `yaml:"enabled" env:"ROUTER_REPLAY_ENABLED"`
 	URL      string        `yaml:"url"`

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -356,6 +356,12 @@ func (s *ServiceConfig) HistoryEnabled() bool {
 	return s.History == nil || s.History.Enabled == nil || *s.History.Enabled
 }
 
+// ReplayEnabled returns whether replay recording and serving is enabled.
+// Defaults to true when not explicitly set.
+func (s *ServiceConfig) ReplayEnabled() bool {
+	return s.Replay == nil || s.Replay.Enabled == nil || *s.Replay.Enabled
+}
+
 // GetUpstream returns the effective upstream config for the given request path
 // and method. An endpoint-level Upstream replaces the service-level Upstream
 // when set; otherwise the service-level Upstream is returned.
@@ -534,6 +540,9 @@ type CacheConfig struct {
 //	            - data.name
 //	            - data.address.zip
 type ReplayConfig struct {
+	// Enabled toggles replay recording and serving (defaults to true when nil).
+	Enabled *bool `yaml:"enabled,omitempty"`
+
 	// Duration is how long recordings are kept. Defaults to the app-level
 	// replay.duration when unset.
 	Duration time.Duration `yaml:"duration"`

--- a/pkg/config/service_test.go
+++ b/pkg/config/service_test.go
@@ -1690,6 +1690,30 @@ func TestHistoryEnabled(t *testing.T) {
 	})
 }
 
+func TestReplayEnabled(t *testing.T) {
+	t.Run("true when Replay is nil", func(t *testing.T) {
+		cfg := &ServiceConfig{}
+		assert.True(t, cfg.ReplayEnabled())
+	})
+
+	t.Run("true when Enabled is nil", func(t *testing.T) {
+		cfg := &ServiceConfig{Replay: &ReplayConfig{}}
+		assert.True(t, cfg.ReplayEnabled())
+	})
+
+	t.Run("true when explicitly enabled", func(t *testing.T) {
+		enabled := true
+		cfg := &ServiceConfig{Replay: &ReplayConfig{Enabled: &enabled}}
+		assert.True(t, cfg.ReplayEnabled())
+	})
+
+	t.Run("false when explicitly disabled", func(t *testing.T) {
+		disabled := false
+		cfg := &ServiceConfig{Replay: &ReplayConfig{Enabled: &disabled}}
+		assert.False(t, cfg.ReplayEnabled())
+	})
+}
+
 func TestHistoryConfig_UnmarshalYAML(t *testing.T) {
 	t.Run("boolean shorthand false", func(t *testing.T) {
 		yamlData := []byte(`history: false`)

--- a/pkg/middleware/replay.go
+++ b/pkg/middleware/replay.go
@@ -120,11 +120,16 @@ func splitFields(s string) []string {
 //   - Empty header value ("") - activates only when the endpoint is configured for this method.
 //     Without config there is no pattern path for placeholders and no match fields to fall back to.
 //   - Auto-replay (no header) - activates only for configured endpoints.
+//   - Disabled (replay.enabled=false) - always skip.
 //   - Otherwise - skip.
 //
 // Returns the match config, the pattern path (for key building), and the actual endpoint path
 // (for extracting path variable values).
 func resolveReplayParams(req *http.Request, cfg *config.ServiceConfig) (match *config.ReplayMatch, patternPath, endpointPath string) {
+	if !cfg.ReplayEnabled() {
+		return nil, "", ""
+	}
+
 	// Check header presence (not just value - empty header is valid)
 	headerValues, headerPresent := req.Header[http.CanonicalHeaderKey(headerReplayMatch)]
 

--- a/pkg/middleware/replay_read_test.go
+++ b/pkg/middleware/replay_read_test.go
@@ -19,6 +19,38 @@ func TestCreateReplayReadMiddleware(t *testing.T) {
 		_, _ = w.Write([]byte("fresh"))
 	})
 
+	t.Run("disabled service does not serve stored recording", func(t *testing.T) {
+		disabled := false
+		params := newTestParams(&config.ServiceConfig{
+			Name: "svc",
+			Replay: &config.ReplayConfig{
+				Enabled:    &disabled,
+				AutoReplay: true,
+				Endpoints: map[string]map[string]*config.ReplayEndpoint{
+					"/foo": {"POST": {Match: &config.ReplayMatch{Body: []string{"name"}}}},
+				},
+			},
+		})
+
+		body := []byte(`{"name":"Jane"}`)
+		key := buildReplayKey(httptest.NewRequest(http.MethodPost, "/foo", nil), "/foo", "/foo", &config.ReplayMatch{Body: []string{"name"}}, body)
+		params.DB().Table("replay").Set(context.TODO(), key, &ReplayRecord{
+			Data:        []byte(`{"result":"stored"}`),
+			StatusCode:  http.StatusOK,
+			ContentType: "application/json",
+			CreatedAt:   time.Now(),
+		}, 0)
+
+		mw := CreateReplayReadMiddleware(params)
+
+		w := NewBufferedResponseWriter()
+		req := httptest.NewRequest(http.MethodPost, "/svc/foo", strings.NewReader(`{"name":"Jane"}`))
+		req.Header.Set(headerReplayMatch, "name")
+		mw(handler).ServeHTTP(w, req)
+
+		assert.Equal("fresh", string(w.buf))
+	})
+
 	t.Run("no header passes through", func(t *testing.T) {
 		params := newTestParams(&config.ServiceConfig{
 			Name: "svc",

--- a/pkg/middleware/replay_test.go
+++ b/pkg/middleware/replay_test.go
@@ -148,6 +148,26 @@ func TestResolveReplayParams(t *testing.T) {
 		assert.Equal("/foo", pattern)
 	})
 
+	t.Run("disabled service skips even with header and auto-replay", func(t *testing.T) {
+		disabled := false
+		cfg := &config.ServiceConfig{
+			Name: "svc",
+			Replay: &config.ReplayConfig{
+				Enabled:    &disabled,
+				AutoReplay: true,
+				Endpoints: map[string]map[string]*config.ReplayEndpoint{
+					"/foo": {"POST": {Match: &config.ReplayMatch{Body: []string{"name"}}}},
+				},
+			},
+		}
+		req := httptest.NewRequest(http.MethodPost, "/svc/foo", nil)
+		req.Header.Set(headerReplayMatch, "age")
+
+		match, pattern, _ := resolveReplayParams(req, cfg)
+		assert.Nil(match)
+		assert.Empty(pattern)
+	})
+
 	t.Run("auto-replay skips non-configured endpoint", func(t *testing.T) {
 		cfg := &config.ServiceConfig{
 			Name: "svc",

--- a/pkg/middleware/replay_write_test.go
+++ b/pkg/middleware/replay_write_test.go
@@ -15,6 +15,34 @@ import (
 func TestCreateReplayWriteMiddleware(t *testing.T) {
 	assert := assert2.New(t)
 
+	t.Run("disabled service does not record even with header", func(t *testing.T) {
+		disabled := false
+		params := newTestParams(&config.ServiceConfig{
+			Name: "svc",
+			Replay: &config.ReplayConfig{
+				Enabled:    &disabled,
+				AutoReplay: true,
+				Endpoints: map[string]map[string]*config.ReplayEndpoint{
+					"/foo": {"POST": {Match: &config.ReplayMatch{Body: []string{"name"}}}},
+				},
+			},
+		})
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		})
+		mw := CreateReplayWriteMiddleware(params)
+
+		w := NewBufferedResponseWriter()
+		req := httptest.NewRequest(http.MethodPost, "/svc/foo", strings.NewReader(`{"name":"test"}`))
+		req.Header.Set(headerReplayMatch, "name")
+		mw(handler).ServeHTTP(w, req)
+		waitForAsync()
+
+		assert.Equal("ok", string(w.buf))
+		data := params.DB().Table("replay").Data(context.TODO())
+		assert.Empty(data)
+	})
+
 	t.Run("no header passes through", func(t *testing.T) {
 		params := newTestParams(&config.ServiceConfig{
 			Name: "svc",


### PR DESCRIPTION
Mirror history's behavior so replay's flag gates record, serve, and UI, with the
same soft per-service precedence.

- Add `Enabled *bool` to the service-level `ReplayConfig` and a `ReplayEnabled()`
  method (defaults to true when unset), paralleling `HistoryEnabled()`.
- In `Router.register()`, when app-level `Replay.Enabled` is explicitly false,
  push `enabled: false` down into each service that has not set its own value.
- Short-circuit `resolveReplayParams` when replay is disabled, which stops both
  the write middleware (record) and the read middleware (serve) in one place.
- Return 404 from the replay explorer for a disabled service, matching history.
- Fix the misleading app-config doc comment.