### PR TITLE
Add service context provider

### DIFF
--- a/cmd/api/templates/handler/chi/handler.tmpl
+++ b/cmd/api/templates/handler/chi/handler.tmpl
@@ -152,7 +152,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/examples/commands/service/petstore/gen.go
+++ b/examples/commands/service/petstore/gen.go
@@ -1736,7 +1736,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/examples/commands/service/static/gen.go
+++ b/examples/commands/service/static/gen.go
@@ -276,7 +276,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/examples/commands/service/users/gen.go
+++ b/examples/commands/service/users/gen.go
@@ -733,7 +733,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/examples/commands/service/zero-endpoints/gen.go
+++ b/examples/commands/service/zero-endpoints/gen.go
@@ -210,7 +210,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/examples/docker-compose/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/petstore/gen.go
@@ -1317,7 +1317,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
@@ -10911,7 +10911,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/examples/docker/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker/pre-generated-services/services/petstore/gen.go
@@ -1317,7 +1317,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/examples/docker/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker/pre-generated-services/services/spoonacular/gen.go
@@ -10911,7 +10911,7 @@ func RegisterAPIRouter(router *api.Router) {
 	}
 
 	// Create the generator with service contexts
-	orderedCtx := generator.LoadServiceContext(contextSrc, router.GetContexts())
+	orderedCtx := router.ServiceContext(serviceName, contextSrc)
 	gen, err := generator.NewGenerator(orderedCtx, router.GetContexts())
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create generator for %s", serviceName),

--- a/internal/contexts/parsers.go
+++ b/internal/contexts/parsers.go
@@ -101,6 +101,15 @@ func Load(files map[string][]byte, parsed []map[string]map[string]any) map[strin
 	return result
 }
 
+// LoadOrdered loads a single service context over the default contexts and
+// returns the replacement maps in resolution order: service, common, fake,
+// words. It is the shared basis for generator.LoadServiceContext and
+// api.Router.ServiceContext.
+func LoadOrdered(serviceCtx []byte, defaultContexts []map[string]map[string]any) []map[string]any {
+	c := Load(map[string][]byte{"service": serviceCtx}, defaultContexts)
+	return []map[string]any{c["service"], c["common"], c["fake"], c["words"]}
+}
+
 // processFunctions recursively processes all string values and converts function prefixes to FakeFunc.
 // It handles nested maps to support structures like fake.internet.url: "fake:internet.url"
 // The full path is already embedded in the string value (e.g., "fake:internet.url") from the generated fake.yml

--- a/internal/contexts/parsers_test.go
+++ b/internal/contexts/parsers_test.go
@@ -357,6 +357,24 @@ nested:
 	})
 }
 
+func TestLoadOrdered(t *testing.T) {
+	t.Parallel()
+	assert := assert2.New(t)
+
+	defaults := []map[string]map[string]any{
+		{"common": {"id": "common-id"}},
+		{"fake": {"email": "fake@example.com"}},
+		{"words": {"word": "lorem"}},
+	}
+	ordered := LoadOrdered([]byte("svc: from-service\n"), defaults)
+
+	assert.Len(ordered, 4) // service, common, fake, words
+	assert.Equal("from-service", ordered[0]["svc"])
+	assert.Equal("common-id", ordered[1]["id"])
+	assert.Equal("fake@example.com", ordered[2]["email"])
+	assert.Equal("lorem", ordered[3]["word"])
+}
+
 func TestProcessFunctions(t *testing.T) {
 	t.Parallel()
 	assert := assert2.New(t)

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -22,9 +22,10 @@ import (
 type Router struct {
 	chi.Router
 
-	config   *config.AppConfig
-	contexts []map[string]map[string]any
-	storage  db.Storage
+	config             *config.AppConfig
+	contexts           []map[string]map[string]any
+	serviceCtxProvider ServiceContextFunc
+	storage            db.Storage
 
 	mu        sync.RWMutex
 	services  map[string]*ServiceItem
@@ -145,6 +146,18 @@ func (r *Router) GetDB(serviceName string) db.DB {
 // GetContexts returns the list of contexts
 func (r *Router) GetContexts() []map[string]map[string]any {
 	return r.contexts
+}
+
+// ServiceContext builds the ordered replacement context a service's generator
+// resolves values against. When a provider is set (WithServiceContextProvider)
+// it may layer extra contexts under the service's own - e.g. a brand default
+// shared across API versions; otherwise it's the plain service-over-defaults
+// order (service, common, fake, words).
+func (r *Router) ServiceContext(serviceName string, serviceCtx []byte) []map[string]any {
+	if r.serviceCtxProvider != nil {
+		return r.serviceCtxProvider(serviceName, serviceCtx, r.contexts)
+	}
+	return contexts.LoadOrdered(serviceCtx, r.contexts)
 }
 
 func (r *Router) register(
@@ -299,6 +312,20 @@ type RouterOption func(*Router)
 func WithConfigOption(cfg *config.AppConfig) RouterOption {
 	return func(r *Router) {
 		r.config = cfg
+	}
+}
+
+// ServiceContextFunc builds the ordered replacement context for a service from
+// its own context bytes and the router's default contexts. Returns the maps in
+// resolution order (highest precedence first).
+type ServiceContextFunc func(serviceName string, serviceCtx []byte, defaults []map[string]map[string]any) []map[string]any
+
+// WithServiceContextProvider overrides how per-service replacement contexts are
+// built, letting a consumer layer shared contexts (e.g. a brand default applied
+// to every API version) under each service's own context.
+func WithServiceContextProvider(fn ServiceContextFunc) RouterOption {
+	return func(r *Router) {
+		r.serviceCtxProvider = fn
 	}
 }
 

--- a/pkg/api/router_test.go
+++ b/pkg/api/router_test.go
@@ -141,6 +141,36 @@ func TestRouter_GetContexts(t *testing.T) {
 	assert.Len(t, contexts, 3) // common, fake, words
 }
 
+func TestRouter_ServiceContext(t *testing.T) {
+	router := newTestRouter(t)
+	ordered := router.ServiceContext("svc", []byte("foo: bar\n"))
+
+	assert.Len(t, ordered, 4) // service, common, fake, words
+	assert.Equal(t, "bar", ordered[0]["foo"], "service context is the highest-precedence layer")
+}
+
+func TestRouter_ServiceContext_Provider(t *testing.T) {
+	var gotName string
+	var gotCtx []byte
+	var gotDefaults []map[string]map[string]any
+	sentinel := []map[string]any{{"sentinel": true}}
+
+	router := NewRouter(
+		WithConfigOption(config.NewDefaultAppConfig(t.TempDir())),
+		WithServiceContextProvider(func(name string, serviceCtx []byte, defaults []map[string]map[string]any) []map[string]any {
+			gotName, gotCtx, gotDefaults = name, serviceCtx, defaults
+			return sentinel
+		}),
+	)
+
+	got := router.ServiceContext("adyen/v71", []byte("k: v\n"))
+
+	assert.Equal(t, "adyen/v71", gotName, "provider receives the service name")
+	assert.Equal(t, []byte("k: v\n"), gotCtx, "provider receives the service context bytes")
+	assert.Len(t, gotDefaults, 3, "provider receives the router's default contexts")
+	assert.Equal(t, sentinel, got, "provider output is returned verbatim")
+}
+
 func TestRouter_RegisterService(t *testing.T) {
 	t.Run("Registers service with routes", func(t *testing.T) {
 		router := newTestRouter(t)

--- a/pkg/generator/context.go
+++ b/pkg/generator/context.go
@@ -17,17 +17,7 @@ import (
 // These namespaces are used during the Load() call to organize and resolve context data,
 // but are discarded in the returned array since only the values are needed for replacement.
 func LoadServiceContext(serviceCtx []byte, defaultContexts []map[string]map[string]any) []map[string]any {
-	combinedCtx := contexts.Load(
-		map[string][]byte{"service": serviceCtx},
-		defaultContexts)
-
-	// names not needed anymore
-	return []map[string]any{
-		combinedCtx["service"],
-		combinedCtx["common"],
-		combinedCtx["fake"],
-		combinedCtx["words"],
-	}
+	return contexts.LoadOrdered(serviceCtx, defaultContexts)
 }
 
 // LoadDefaultContexts loads the built-in replacement contexts (common, fake, words).


### PR DESCRIPTION
## Pluggable per-service context provider

Adds an opt-in hook that lets a mockzilla-based product control how each service's mock-data (replacement) context is assembled.

## Why it matters

- **Define mock-data shaping once, reuse across versions.** A service with many API versions can share a single context instead of copy-pasting the same config into every version - less duplication, no drift between versions.
- **Lower maintenance cost.** New API versions ship with realistic, consistent mock data out of the box, with no per-version context authoring step.
- **Safe in multi-service deployments.** Shared context stays scoped to the service that owns it; one service's data never bleeds into another's responses.

