### PR TITLE
Bind the HTTP listener before registering services

### DIFF
--- a/internal/portable/runner.go
+++ b/internal/portable/runner.go
@@ -49,6 +49,7 @@ type Setup struct {
 
 	handlers    map[string]*swappableHandler
 	flags       flags
+	listener    net.Listener
 	validatorWG sync.WaitGroup
 }
 
@@ -86,9 +87,9 @@ type FailedService struct {
 	Err  error
 }
 
-// BuildSetup runs the portable startup pipeline up to port binding. Does NOT
-// call configureLogger; Run does that, but in-process callers keep their own
-// slog config.
+// BuildSetup runs the portable startup pipeline, binding the listener before
+// registering services. Does NOT call configureLogger; Run does that, but
+// in-process callers keep their own slog config.
 func BuildSetup(args []string) (*Setup, error) {
 	fl, positional := parseFlags(args)
 
@@ -151,11 +152,19 @@ func BuildSetup(args []string) (*Setup, error) {
 		return nil, fmt.Errorf("convenience flags (--latency/--mount/--errors/--context) require exactly one service, got %d", len(services))
 	}
 
+	// Bind before registering services so connections that arrive during the
+	// spec parse queue in the backlog instead of being refused.
+	listener, err := bindListener(appCfg)
+	if err != nil {
+		return nil, err
+	}
+
 	handlers := make(map[string]*swappableHandler)
 	setup := &Setup{
 		Router:   router,
 		AppCfg:   appCfg,
 		Services: services,
+		listener: listener,
 		handlers: handlers,
 		flags:    fl,
 	}
@@ -185,11 +194,6 @@ func Run(args []string) int {
 		return exitCodeError
 	}
 
-	listener, err := bindListener(setup.AppCfg)
-	if err != nil {
-		return exitCodeError
-	}
-
 	if setup.flags.readyStamp {
 		emitReadyStamp(setup.AppCfg, setup.Router)
 	}
@@ -203,7 +207,7 @@ func Run(args []string) int {
 
 	go func() {
 		slog.Info(fmt.Sprintf("Mockzilla portable mode on http://localhost:%d%s", setup.AppCfg.Port, setup.AppCfg.HomeURL))
-		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := server.Serve(setup.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("Server failed", "error", err)
 			os.Exit(1)
 		}

--- a/internal/portable/runner_test.go
+++ b/internal/portable/runner_test.go
@@ -1,7 +1,9 @@
 package portable
 
 import (
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,6 +11,7 @@ import (
 	"sync"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/mockzilla/mockzilla/v2/pkg/api"
 	"github.com/stretchr/testify/assert"
@@ -454,4 +457,31 @@ func TestIntegration_StaticFallbackWithMount(t *testing.T) {
 			assert.JSONEq(t, `{"hi":"there"}`, string(body))
 		})
 	}
+}
+
+func TestBuildSetupBindsListenerBeforeServing(t *testing.T) {
+	dir := t.TempDir()
+	spec := filepath.Join(dir, "openapi.yml")
+	require.NoError(t, os.WriteFile(spec, []byte("openapi: 3.0.0\ninfo:\n  title: t\n  version: \"1\"\npaths: {}\n"), 0o644))
+
+	setup, err := BuildSetup([]string{spec, "--port", "0"})
+	require.NoError(t, err)
+	require.NotNil(t, setup.listener, "BuildSetup must bind the listener before registering services")
+	t.Cleanup(func() { _ = setup.listener.Close() })
+
+	addr := fmt.Sprintf("127.0.0.1:%d", setup.listener.Addr().(*net.TCPAddr).Port)
+
+	// Bound before Serve, so a connection here queues in the backlog, not refused.
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require.NoError(t, err)
+	_ = conn.Close()
+
+	srv := &http.Server{Handler: setup.Router}
+	go func() { _ = srv.Serve(setup.listener) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	resp, err := http.Get("http://" + addr + "/healthz")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
## Bind the HTTP listener before registering services

## Why this matters

When mockzilla starts, there is a short window between process launch and the HTTP server accepting connections. Until now the listening socket was opened *after* every service and its OpenAPI spec had been parsed and registered - a step that grows with the size and number of specs. Any request that arrived during that window was refused at the TCP level, so the client saw a dropped connection or a timeout instead of a real response.

This bites hardest in automated, high-churn setups - CI pipelines, containers, autoscaled fleets, and anything fronted by a health check or load balancer that sends traffic the moment the process comes up. In those environments the first request after every start or restart could intermittently fail even though the server was healthy a moment later. The result is flaky, hard-to-diagnose failures and lost trust in the mock.

## What changed

mockzilla now binds the listener **before** registering services. Once the socket is bound, the OS queues incoming connections in the backlog and the server serves them as soon as route registration finishes. Requests that arrive during startup now wait briefly and get a correct response instead of being refused.

- No change to behavior or performance once the server is serving.
- No new configuration, dependencies, or breaking changes.
- The listener is bound only after all validation/error checks, so bad input still fails cleanly before any socket is opened.

## Impact

- Removes a class of intermittent connection-refused / timeout failures on the first request(s) after startup.
- More reliable behavior behind health checks, load balancers, and orchestrators that probe immediately on launch.
- Fewer flaky pipeline failures and less time chasing phantom startup errors.