### PR TITLE
Fix admin UI double-prepending origin when AppConfig.BaseURL is absolute

### DIFF
--- a/resources/ui/js/config.js
+++ b/resources/ui/js/config.js
@@ -1,10 +1,12 @@
+import { resolveConfigUrl } from './url.js';
+
 export const url = window.location.origin;
-export const baseUrl = `${url}${appConfig.baseUrl || ''}`;
-export const serviceUrl = `${url}${appConfig.serviceUrl}`;
+export const baseUrl = resolveConfigUrl(url, appConfig.baseUrl);
+export const serviceUrl = resolveConfigUrl(url, appConfig.serviceUrl);
 export const historyEnabled = !!appConfig.historyUrl;
-export const historyUrl = appConfig.historyUrl ? `${url}${appConfig.historyUrl}` : '';
+export const historyUrl = resolveConfigUrl(url, appConfig.historyUrl);
 export const replayEnabled = !!appConfig.replayUrl;
-export const replayUrl = appConfig.replayUrl ? `${url}${appConfig.replayUrl}` : '';
+export const replayUrl = resolveConfigUrl(url, appConfig.replayUrl);
 export const configEnabled = !appConfig.disableConfigUI;
 export const version = appConfig.version;
 export const editor = appConfig.editor;

--- a/resources/ui/js/url.js
+++ b/resources/ui/js/url.js
@@ -8,3 +8,14 @@ export const joinServiceUrl = (baseUrl, prefix, path) => {
     if (p === '' || p === '/') return `${baseUrl}${path}`;
     return `${baseUrl}${p.replace(/\/+$/, '')}${path}`;
 };
+
+// resolveConfigUrl resolves one of the appConfig.*Url fields sent by the
+// index.html template, which already joins AppConfig.BaseURL onto the path
+// server-side. BaseURL is empty by default (same-origin), so the field is a
+// bare path and origin must be added; but it can be a customer's public URL
+// (APP_BASE_URL, for redirect links a payment engine builds), in which case
+// the field already arrives absolute and must be used as-is.
+export const resolveConfigUrl = (origin, v) => {
+    if (!v) return '';
+    return /^https?:\/\//i.test(v) ? v : `${origin}${v}`;
+};

--- a/resources/ui/js/url.test.js
+++ b/resources/ui/js/url.test.js
@@ -1,7 +1,7 @@
 // Run with: node --test resources/ui/js/url.test.js
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { joinServiceUrl } from './url.js';
+import { joinServiceUrl, resolveConfigUrl } from './url.js';
 
 const BASE = 'http://localhost:2200';
 
@@ -35,4 +35,20 @@ test('empty or nullish prefix joins base + path directly', () => {
 test('paths with query strings round-trip through the join', () => {
     assert.equal(joinServiceUrl(BASE, '/foo/bar', '/items?q=1'), 'http://localhost:2200/foo/bar/items?q=1');
     assert.equal(joinServiceUrl(BASE, '/', '/?q=1'), 'http://localhost:2200/?q=1');
+});
+
+test('resolveConfigUrl: relative path is joined onto origin', () => {
+    assert.equal(resolveConfigUrl(BASE, '/.services'), 'http://localhost:2200/.services');
+    assert.equal(resolveConfigUrl(BASE, '/'), 'http://localhost:2200/');
+});
+
+test('resolveConfigUrl: already-absolute value (AppConfig.BaseURL set, e.g. APP_BASE_URL) passes through unchanged', () => {
+    assert.equal(resolveConfigUrl(BASE, 'http://localhost:2200/.services'), 'http://localhost:2200/.services');
+    assert.equal(resolveConfigUrl(BASE, 'https://payments.example.com/.services'), 'https://payments.example.com/.services');
+});
+
+test('resolveConfigUrl: empty or nullish value resolves to empty string', () => {
+    assert.equal(resolveConfigUrl(BASE, ''), '');
+    assert.equal(resolveConfigUrl(BASE, null), '');
+    assert.equal(resolveConfigUrl(BASE, undefined), '');
 });


### PR DESCRIPTION
index.html already joins AppConfig.BaseURL onto serviceUrl/historyUrl/etc server-side; config.js then prepended window.location.origin again unconditionally, breaking every admin-UI fetch whenever BaseURL is a full URL (e.g. APP_BASE_URL set for a payment engine's redirect links) instead of the empty same-origin default.