### PR TITLE
Always pass opts to generated service methods

### DIFF
--- a/cmd/api/templates/handler/chi/handler.tmpl
+++ b/cmd/api/templates/handler/chi/handler.tmpl
@@ -272,6 +272,21 @@ func (h *serviceHandler) Generate(w http.ResponseWriter, r *http.Request) {
 // Generator Service (fallback to mock responses)
 // ============================================================================
 
+{{- range $operations }}{{ $op := . }}
+{{- if not $op.HasRequestOptions }}
+
+// {{ $op.ID | ucFirst }}ServiceRequestOptions holds all parameters for the {{ $op.ID }} operation.
+type {{ $op.ID | ucFirst }}ServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	{{- if $op.Response.Success }}
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*{{ $op.ID | ucFirst }}ResponseData, error)
+	{{- end }}
+}
+{{- end }}
+{{- end }}
+
 // generatorService implements ServiceInterface with generator fallback.
 // It delegates to the user's service first; if that returns nil, it generates a mock response.
 type generatorService struct {
@@ -289,8 +304,10 @@ var _ {{ $modelsPrefix }}ServiceInterface = (*generatorService)(nil)
 {{- if and (not $config.Generate.OmitDescription) $op.Summary }}
 {{ toGoComment $op.Summary "" }}
 {{- end }}
-{{- if $op.HasRequestOptions }}
-func (s *generatorService) {{ $op.ID }}(ctx context.Context, opts *{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ServiceRequestOptions) ({{ if $op.Response.Success }}*{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ResponseData, error{{ else }}error{{ end }}) {
+func (s *generatorService) {{ $op.ID }}(ctx context.Context{{ if $op.HasRequestOptions }}, opts *{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ServiceRequestOptions{{ end }}) ({{ if $op.Response.Success }}*{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ResponseData, error{{ else }}error{{ end }}) {
+	{{- if not $op.HasRequestOptions }}
+	opts := &{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	{{- end }}
 	{{- if $op.Response.Success }}
 	// Inject GenerateResponse so user service can call it
 	opts.GenerateResponse = func() (*{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ResponseData, error) {
@@ -331,48 +348,6 @@ func (s *generatorService) {{ $op.ID }}(ctx context.Context, opts *{{ $modelsPre
 	return nil
 	{{- end }}
 }
-{{- else }}
-func (s *generatorService) {{ $op.ID }}(ctx context.Context) ({{ if $op.Response.Success }}*{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ResponseData, error{{ else }}error{{ end }}) {
-	// Call user's service first
-	if resp, err := s.service.{{ $op.ID }}(ctx); resp != nil || err != nil {
-		return resp, err
-	}
-
-	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("{{ $op.Path }}", "{{ $op.Method }}")
-	if respSchema == nil {
-		{{- if $op.Response.Success }}
-		return {{ $modelsPrefix }}New{{ $op.ID | ucFirst }}ResponseData(nil), nil
-		{{- else }}
-		return nil
-		{{- end }}
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	{{- if $op.Response.Success }}
-	{{- $bodyType := $op.Response.Success.ResponseName -}}
-	{{- if eq $bodyType "struct{}" }}
-	return {{ $modelsPrefix }}New{{ $op.ID | ucFirst }}ResponseData(nil).WithHeaders(res.Headers), nil
-	{{- else if $op.Response.Success.IsRaw }}
-	return {{ $modelsPrefix }}New{{ $op.ID | ucFirst }}ResponseData(res.Body).WithHeaders(res.Headers), nil
-	{{- else }}
-	{{- if $modelsPrefix }}{{ $bodyType = printf "%s%s" $modelsPrefix $bodyType }}{{ end }}
-	var body {{ $bodyType }}
-	if err := api.UnmarshalResponseInto(res.Body, "{{ $op.Response.Success.ContentType | escapeGoString }}", &body); err != nil {
-		return nil, err
-	}
-	{{- if eq $op.Response.Success.Schema.GoType "[]byte" }}
-	return {{ $modelsPrefix }}New{{ $op.ID | ucFirst }}ResponseData(body).WithHeaders(res.Headers), nil
-	{{- else }}
-	return {{ $modelsPrefix }}New{{ $op.ID | ucFirst }}ResponseData(&body).WithHeaders(res.Headers), nil
-	{{- end }}
-	{{- end }}
-	{{- else }}
-	_ = res
-	return nil
-	{{- end }}
-}
-{{- end }}
 {{- end }}
 
 // ============================================================================

--- a/cmd/api/templates/handler/service.tmpl
+++ b/cmd/api/templates/handler/service.tmpl
@@ -34,9 +34,6 @@ type service struct {
 }
 {{- end }}
 
-// Ensure service implements ServiceInterface.
-var _ {{ $modelsPrefix }}ServiceInterface = (*{{ $serviceName }})(nil)
-
 {{- block "service-constructor" . }}
 
 // newService creates a new service instance.
@@ -51,17 +48,9 @@ func newService(params *api.ServiceParams) *service {
 {{- if and (not $config.Generate.OmitDescription) $op.Summary }}
 {{ toGoComment $op.Summary "" }}
 {{- end }}
-{{- if $op.HasRequestOptions }}
 func ({{ $receiver }} *{{ $serviceName }}) {{ $op.ID }}(ctx context.Context, opts *{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ServiceRequestOptions) ({{ if $op.Response.Success }}*{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ResponseData, error{{ else }}error{{ end }}) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil
 }
-{{- else }}
-func ({{ $receiver }} *{{ $serviceName }}) {{ $op.ID }}(ctx context.Context) ({{ if $op.Response.Success }}*{{ $modelsPrefix }}{{ $op.ID | ucFirst }}ResponseData, error{{ else }}error{{ end }}) {
-	// TODO: Implement your business logic here.
-	// Return nil, nil to use the generated mock response.
-	return nil, nil
-}
-{{- end }}
 {{- end }}

--- a/docs/services.md
+++ b/docs/services.md
@@ -215,9 +215,9 @@ pkg/petstore/
 └── middleware.go         # custom middleware (kept across regen)
 ```
 
-When implementing a service method, use `opts.GenerateResponse()` to
-get a spec-compliant response with generated values, then modify
-specific fields:
+Every service method receives `opts`, including operations without
+parameters. Use `opts.GenerateResponse()` to get a spec-compliant
+response with generated values, then modify specific fields:
 
 ```go
 func (s *service) GetUser(ctx context.Context, opts *GetUserServiceRequestOptions) (*GetUserResponseData, error) {

--- a/docs/usage/codegen.md
+++ b/docs/usage/codegen.md
@@ -99,7 +99,7 @@ go generate ./...
 
 ## Customizing Handlers
 
-Each operation gets a method in `service.go`. Return `nil, nil` to use the auto-generated mock response, or return your own:
+Each operation gets a method in `service.go` taking `opts`, even when the endpoint declares no parameters (there `opts` carries only `RawRequest` and `GenerateResponse`). Return `nil, nil` to use the auto-generated mock response, or return your own:
 
 ```go
 func (s *service) GetPetByID(ctx context.Context, opts *GetPetByIDServiceRequestOptions) (*GetPetByIDResponseData, error) {

--- a/examples/commands/service/petstore/gen.go
+++ b/examples/commands/service/petstore/gen.go
@@ -1837,6 +1837,22 @@ func (h *serviceHandler) Generate(w http.ResponseWriter, r *http.Request) {
 // Generator Service (fallback to mock responses)
 // ============================================================================
 
+// GetInventoryServiceRequestOptions holds all parameters for the GetInventory operation.
+type GetInventoryServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*GetInventoryResponseData, error)
+}
+
+// LogoutUserServiceRequestOptions holds all parameters for the LogoutUser operation.
+type LogoutUserServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*LogoutUserResponseData, error)
+}
+
 // generatorService implements ServiceInterface with generator fallback.
 // It delegates to the user's service first; if that returns nil, it generates a mock response.
 type generatorService struct {
@@ -2046,23 +2062,28 @@ func (s *generatorService) UploadFile(ctx context.Context, opts *UploadFileServi
 
 // GetInventory handles GET /store/inventory
 func (s *generatorService) GetInventory(ctx context.Context) (*GetInventoryResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.GetInventory(ctx); resp != nil || err != nil {
+	opts := &GetInventoryServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*GetInventoryResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/store/inventory", "GET")
+		if respSchema == nil {
+			return NewGetInventoryResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		var body GetInventoryResponse
+		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
+			return nil, err
+		}
+		return NewGetInventoryResponseData(&body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.GetInventory(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/store/inventory", "GET")
-	if respSchema == nil {
-		return NewGetInventoryResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	var body GetInventoryResponse
-	if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
-		return nil, err
-	}
-	return NewGetInventoryResponseData(&body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // PlaceOrder handles POST /store/order
@@ -2213,19 +2234,24 @@ func (s *generatorService) LoginUser(ctx context.Context, opts *LoginUserService
 
 // LogoutUser handles GET /user/logout
 func (s *generatorService) LogoutUser(ctx context.Context) (*LogoutUserResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.LogoutUser(ctx); resp != nil || err != nil {
+	opts := &LogoutUserServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*LogoutUserResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/user/logout", "GET")
+		if respSchema == nil {
+			return NewLogoutUserResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.LogoutUser(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/user/logout", "GET")
-	if respSchema == nil {
-		return NewLogoutUserResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // GetUserByName handles GET /user/{username}

--- a/examples/commands/service/petstore/service.go
+++ b/examples/commands/service/petstore/service.go
@@ -17,9 +17,6 @@ type service struct {
 	params *api.ServiceParams
 }
 
-// Ensure service implements ServiceInterface.
-var _ ServiceInterface = (*service)(nil)
-
 // newService creates a new service instance.
 func newService(params *api.ServiceParams) *service {
 	return &service{params: params}
@@ -82,7 +79,7 @@ func (s *service) UploadFile(ctx context.Context, opts *UploadFileServiceRequest
 }
 
 // GetInventory handles GET /store/inventory
-func (s *service) GetInventory(ctx context.Context) (*GetInventoryResponseData, error) {
+func (s *service) GetInventory(ctx context.Context, opts *GetInventoryServiceRequestOptions) (*GetInventoryResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil
@@ -131,7 +128,7 @@ func (s *service) LoginUser(ctx context.Context, opts *LoginUserServiceRequestOp
 }
 
 // LogoutUser handles GET /user/logout
-func (s *service) LogoutUser(ctx context.Context) (*LogoutUserResponseData, error) {
+func (s *service) LogoutUser(ctx context.Context, opts *LogoutUserServiceRequestOptions) (*LogoutUserResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil

--- a/examples/commands/service/static/service.go
+++ b/examples/commands/service/static/service.go
@@ -17,9 +17,6 @@ type service struct {
 	params *api.ServiceParams
 }
 
-// Ensure service implements ServiceInterface.
-var _ ServiceInterface = (*service)(nil)
-
 // newService creates a new service instance.
 func newService(params *api.ServiceParams) *service {
 	return &service{params: params}

--- a/examples/commands/service/users/gen.go
+++ b/examples/commands/service/users/gen.go
@@ -834,6 +834,30 @@ func (h *serviceHandler) Generate(w http.ResponseWriter, r *http.Request) {
 // Generator Service (fallback to mock responses)
 // ============================================================================
 
+// ListUsersServiceRequestOptions holds all parameters for the ListUsers operation.
+type ListUsersServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*ListUsersResponseData, error)
+}
+
+// ExportUsersServiceRequestOptions holds all parameters for the ExportUsers operation.
+type ExportUsersServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*ExportUsersResponseData, error)
+}
+
+// StreamUsersServiceRequestOptions holds all parameters for the StreamUsers operation.
+type StreamUsersServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*StreamUsersResponseData, error)
+}
+
 // generatorService implements ServiceInterface with generator fallback.
 // It delegates to the user's service first; if that returns nil, it generates a mock response.
 type generatorService struct {
@@ -847,23 +871,28 @@ var _ ServiceInterface = (*generatorService)(nil)
 
 // ListUsers handles GET /users
 func (s *generatorService) ListUsers(ctx context.Context) (*ListUsersResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.ListUsers(ctx); resp != nil || err != nil {
+	opts := &ListUsersServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*ListUsersResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/users", "GET")
+		if respSchema == nil {
+			return NewListUsersResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		var body ListUsersResponse
+		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
+			return nil, err
+		}
+		return NewListUsersResponseData(&body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.ListUsers(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/users", "GET")
-	if respSchema == nil {
-		return NewListUsersResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	var body ListUsersResponse
-	if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
-		return nil, err
-	}
-	return NewListUsersResponseData(&body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // GetUser handles GET /users/{id}
@@ -939,19 +968,24 @@ func (s *generatorService) GetUserProfile(ctx context.Context, opts *GetUserProf
 
 // ExportUsers handles GET /users/export
 func (s *generatorService) ExportUsers(ctx context.Context) (*ExportUsersResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.ExportUsers(ctx); resp != nil || err != nil {
+	opts := &ExportUsersServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*ExportUsersResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/users/export", "GET")
+		if respSchema == nil {
+			return NewExportUsersResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		return NewExportUsersResponseData(res.Body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.ExportUsers(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/users/export", "GET")
-	if respSchema == nil {
-		return NewExportUsersResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	return NewExportUsersResponseData(res.Body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // GetUserConfig handles GET /users/{id}/config
@@ -1052,19 +1086,24 @@ func (s *generatorService) GetUserProblem(ctx context.Context, opts *GetUserProb
 
 // StreamUsers handles GET /users/stream
 func (s *generatorService) StreamUsers(ctx context.Context) (*StreamUsersResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.StreamUsers(ctx); resp != nil || err != nil {
+	opts := &StreamUsersServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*StreamUsersResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/users/stream", "GET")
+		if respSchema == nil {
+			return NewStreamUsersResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		return NewStreamUsersResponseData(res.Body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.StreamUsers(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/users/stream", "GET")
-	if respSchema == nil {
-		return NewStreamUsersResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	return NewStreamUsersResponseData(res.Body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // GetUserPdf handles GET /users/{id}/pdf

--- a/examples/commands/service/users/service.go
+++ b/examples/commands/service/users/service.go
@@ -17,16 +17,13 @@ type service struct {
 	params *api.ServiceParams
 }
 
-// Ensure service implements ServiceInterface.
-var _ ServiceInterface = (*service)(nil)
-
 // newService creates a new service instance.
 func newService(params *api.ServiceParams) *service {
 	return &service{params: params}
 }
 
 // ListUsers handles GET /users
-func (s *service) ListUsers(ctx context.Context) (*ListUsersResponseData, error) {
+func (s *service) ListUsers(ctx context.Context, opts *ListUsersServiceRequestOptions) (*ListUsersResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil
@@ -54,7 +51,7 @@ func (s *service) GetUserProfile(ctx context.Context, opts *GetUserProfileServic
 }
 
 // ExportUsers handles GET /users/export
-func (s *service) ExportUsers(ctx context.Context) (*ExportUsersResponseData, error) {
+func (s *service) ExportUsers(ctx context.Context, opts *ExportUsersServiceRequestOptions) (*ExportUsersResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil
@@ -89,7 +86,7 @@ func (s *service) GetUserProblem(ctx context.Context, opts *GetUserProblemServic
 }
 
 // StreamUsers handles GET /users/stream
-func (s *service) StreamUsers(ctx context.Context) (*StreamUsersResponseData, error) {
+func (s *service) StreamUsers(ctx context.Context, opts *StreamUsersServiceRequestOptions) (*StreamUsersResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil

--- a/examples/commands/service/zero-endpoints/service.go
+++ b/examples/commands/service/zero-endpoints/service.go
@@ -15,9 +15,6 @@ type service struct {
 	params *api.ServiceParams
 }
 
-// Ensure service implements ServiceInterface.
-var _ ServiceInterface = (*service)(nil)
-
 // newService creates a new service instance.
 func newService(params *api.ServiceParams) *service {
 	return &service{params: params}

--- a/examples/docker-compose/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/petstore/gen.go
@@ -1418,6 +1418,22 @@ func (h *serviceHandler) Generate(w http.ResponseWriter, r *http.Request) {
 // Generator Service (fallback to mock responses)
 // ============================================================================
 
+// GetInventoryServiceRequestOptions holds all parameters for the GetInventory operation.
+type GetInventoryServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*GetInventoryResponseData, error)
+}
+
+// LogoutUserServiceRequestOptions holds all parameters for the LogoutUser operation.
+type LogoutUserServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*LogoutUserResponseData, error)
+}
+
 // generatorService implements ServiceInterface with generator fallback.
 // It delegates to the user's service first; if that returns nil, it generates a mock response.
 type generatorService struct {
@@ -1627,23 +1643,28 @@ func (s *generatorService) UploadFile(ctx context.Context, opts *UploadFileServi
 
 // GetInventory handles GET /store/inventory
 func (s *generatorService) GetInventory(ctx context.Context) (*GetInventoryResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.GetInventory(ctx); resp != nil || err != nil {
+	opts := &GetInventoryServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*GetInventoryResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/store/inventory", "GET")
+		if respSchema == nil {
+			return NewGetInventoryResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		var body GetInventoryResponse
+		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
+			return nil, err
+		}
+		return NewGetInventoryResponseData(&body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.GetInventory(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/store/inventory", "GET")
-	if respSchema == nil {
-		return NewGetInventoryResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	var body GetInventoryResponse
-	if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
-		return nil, err
-	}
-	return NewGetInventoryResponseData(&body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // PlaceOrder handles POST /store/order
@@ -1794,19 +1815,24 @@ func (s *generatorService) LoginUser(ctx context.Context, opts *LoginUserService
 
 // LogoutUser handles GET /user/logout
 func (s *generatorService) LogoutUser(ctx context.Context) (*LogoutUserResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.LogoutUser(ctx); resp != nil || err != nil {
+	opts := &LogoutUserServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*LogoutUserResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/user/logout", "GET")
+		if respSchema == nil {
+			return NewLogoutUserResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.LogoutUser(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/user/logout", "GET")
-	if respSchema == nil {
-		return NewLogoutUserResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // GetUserByName handles GET /user/{username}

--- a/examples/docker-compose/pre-generated-services/services/petstore/service.go
+++ b/examples/docker-compose/pre-generated-services/services/petstore/service.go
@@ -17,9 +17,6 @@ type service struct {
 	params *api.ServiceParams
 }
 
-// Ensure service implements ServiceInterface.
-var _ ServiceInterface = (*service)(nil)
-
 // newService creates a new service instance.
 func newService(params *api.ServiceParams) *service {
 	return &service{params: params}
@@ -82,7 +79,7 @@ func (s *service) UploadFile(ctx context.Context, opts *UploadFileServiceRequest
 }
 
 // GetInventory handles GET /store/inventory
-func (s *service) GetInventory(ctx context.Context) (*GetInventoryResponseData, error) {
+func (s *service) GetInventory(ctx context.Context, opts *GetInventoryServiceRequestOptions) (*GetInventoryResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil
@@ -131,7 +128,7 @@ func (s *service) LoginUser(ctx context.Context, opts *LoginUserServiceRequestOp
 }
 
 // LogoutUser handles GET /user/logout
-func (s *service) LogoutUser(ctx context.Context) (*LogoutUserResponseData, error) {
+func (s *service) LogoutUser(ctx context.Context, opts *LogoutUserServiceRequestOptions) (*LogoutUserResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil

--- a/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
@@ -11012,6 +11012,22 @@ func (h *serviceHandler) Generate(w http.ResponseWriter, r *http.Request) {
 // Generator Service (fallback to mock responses)
 // ============================================================================
 
+// GetARandomFoodJokeServiceRequestOptions holds all parameters for the GetARandomFoodJoke operation.
+type GetARandomFoodJokeServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*GetARandomFoodJokeResponseData, error)
+}
+
+// GetRandomFoodTriviaServiceRequestOptions holds all parameters for the GetRandomFoodTrivia operation.
+type GetRandomFoodTriviaServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*GetRandomFoodTriviaResponseData, error)
+}
+
 // generatorService implements ServiceInterface with generator fallback.
 // It delegates to the user's service first; if that returns nil, it generates a mock response.
 type generatorService struct {
@@ -13360,44 +13376,54 @@ func (s *generatorService) SearchFoodVideos(ctx context.Context, opts *SearchFoo
 
 // GetARandomFoodJoke handles GET /food/jokes/random
 func (s *generatorService) GetARandomFoodJoke(ctx context.Context) (*GetARandomFoodJokeResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.GetARandomFoodJoke(ctx); resp != nil || err != nil {
+	opts := &GetARandomFoodJokeServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*GetARandomFoodJokeResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/food/jokes/random", "GET")
+		if respSchema == nil {
+			return NewGetARandomFoodJokeResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		var body GetARandomFoodJokeResponse
+		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
+			return nil, err
+		}
+		return NewGetARandomFoodJokeResponseData(&body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.GetARandomFoodJoke(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/food/jokes/random", "GET")
-	if respSchema == nil {
-		return NewGetARandomFoodJokeResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	var body GetARandomFoodJokeResponse
-	if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
-		return nil, err
-	}
-	return NewGetARandomFoodJokeResponseData(&body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // GetRandomFoodTrivia handles GET /food/trivia/random
 func (s *generatorService) GetRandomFoodTrivia(ctx context.Context) (*GetRandomFoodTriviaResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.GetRandomFoodTrivia(ctx); resp != nil || err != nil {
+	opts := &GetRandomFoodTriviaServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*GetRandomFoodTriviaResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/food/trivia/random", "GET")
+		if respSchema == nil {
+			return NewGetRandomFoodTriviaResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		var body GetRandomFoodTriviaResponse
+		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
+			return nil, err
+		}
+		return NewGetRandomFoodTriviaResponseData(&body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.GetRandomFoodTrivia(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/food/trivia/random", "GET")
-	if respSchema == nil {
-		return NewGetRandomFoodTriviaResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	var body GetRandomFoodTriviaResponse
-	if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
-		return nil, err
-	}
-	return NewGetRandomFoodTriviaResponseData(&body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // TalkToChatbot handles GET /food/converse

--- a/examples/docker-compose/pre-generated-services/services/spoonacular/service.go
+++ b/examples/docker-compose/pre-generated-services/services/spoonacular/service.go
@@ -17,9 +17,6 @@ type service struct {
 	params *api.ServiceParams
 }
 
-// Ensure service implements ServiceInterface.
-var _ ServiceInterface = (*service)(nil)
-
 // newService creates a new service instance.
 func newService(params *api.ServiceParams) *service {
 	return &service{params: params}
@@ -691,14 +688,14 @@ func (s *service) SearchFoodVideos(ctx context.Context, opts *SearchFoodVideosSe
 }
 
 // GetARandomFoodJoke handles GET /food/jokes/random
-func (s *service) GetARandomFoodJoke(ctx context.Context) (*GetARandomFoodJokeResponseData, error) {
+func (s *service) GetARandomFoodJoke(ctx context.Context, opts *GetARandomFoodJokeServiceRequestOptions) (*GetARandomFoodJokeResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil
 }
 
 // GetRandomFoodTrivia handles GET /food/trivia/random
-func (s *service) GetRandomFoodTrivia(ctx context.Context) (*GetRandomFoodTriviaResponseData, error) {
+func (s *service) GetRandomFoodTrivia(ctx context.Context, opts *GetRandomFoodTriviaServiceRequestOptions) (*GetRandomFoodTriviaResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil

--- a/examples/docker/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker/pre-generated-services/services/petstore/gen.go
@@ -1418,6 +1418,22 @@ func (h *serviceHandler) Generate(w http.ResponseWriter, r *http.Request) {
 // Generator Service (fallback to mock responses)
 // ============================================================================
 
+// GetInventoryServiceRequestOptions holds all parameters for the GetInventory operation.
+type GetInventoryServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*GetInventoryResponseData, error)
+}
+
+// LogoutUserServiceRequestOptions holds all parameters for the LogoutUser operation.
+type LogoutUserServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*LogoutUserResponseData, error)
+}
+
 // generatorService implements ServiceInterface with generator fallback.
 // It delegates to the user's service first; if that returns nil, it generates a mock response.
 type generatorService struct {
@@ -1627,23 +1643,28 @@ func (s *generatorService) UploadFile(ctx context.Context, opts *UploadFileServi
 
 // GetInventory handles GET /store/inventory
 func (s *generatorService) GetInventory(ctx context.Context) (*GetInventoryResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.GetInventory(ctx); resp != nil || err != nil {
+	opts := &GetInventoryServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*GetInventoryResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/store/inventory", "GET")
+		if respSchema == nil {
+			return NewGetInventoryResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		var body GetInventoryResponse
+		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
+			return nil, err
+		}
+		return NewGetInventoryResponseData(&body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.GetInventory(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/store/inventory", "GET")
-	if respSchema == nil {
-		return NewGetInventoryResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	var body GetInventoryResponse
-	if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
-		return nil, err
-	}
-	return NewGetInventoryResponseData(&body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // PlaceOrder handles POST /store/order
@@ -1794,19 +1815,24 @@ func (s *generatorService) LoginUser(ctx context.Context, opts *LoginUserService
 
 // LogoutUser handles GET /user/logout
 func (s *generatorService) LogoutUser(ctx context.Context) (*LogoutUserResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.LogoutUser(ctx); resp != nil || err != nil {
+	opts := &LogoutUserServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*LogoutUserResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/user/logout", "GET")
+		if respSchema == nil {
+			return NewLogoutUserResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.LogoutUser(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/user/logout", "GET")
-	if respSchema == nil {
-		return NewLogoutUserResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // GetUserByName handles GET /user/{username}

--- a/examples/docker/pre-generated-services/services/petstore/service.go
+++ b/examples/docker/pre-generated-services/services/petstore/service.go
@@ -17,9 +17,6 @@ type service struct {
 	params *api.ServiceParams
 }
 
-// Ensure service implements ServiceInterface.
-var _ ServiceInterface = (*service)(nil)
-
 // newService creates a new service instance.
 func newService(params *api.ServiceParams) *service {
 	return &service{params: params}
@@ -82,7 +79,7 @@ func (s *service) UploadFile(ctx context.Context, opts *UploadFileServiceRequest
 }
 
 // GetInventory handles GET /store/inventory
-func (s *service) GetInventory(ctx context.Context) (*GetInventoryResponseData, error) {
+func (s *service) GetInventory(ctx context.Context, opts *GetInventoryServiceRequestOptions) (*GetInventoryResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil
@@ -131,7 +128,7 @@ func (s *service) LoginUser(ctx context.Context, opts *LoginUserServiceRequestOp
 }
 
 // LogoutUser handles GET /user/logout
-func (s *service) LogoutUser(ctx context.Context) (*LogoutUserResponseData, error) {
+func (s *service) LogoutUser(ctx context.Context, opts *LogoutUserServiceRequestOptions) (*LogoutUserResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil

--- a/examples/docker/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker/pre-generated-services/services/spoonacular/gen.go
@@ -11012,6 +11012,22 @@ func (h *serviceHandler) Generate(w http.ResponseWriter, r *http.Request) {
 // Generator Service (fallback to mock responses)
 // ============================================================================
 
+// GetARandomFoodJokeServiceRequestOptions holds all parameters for the GetARandomFoodJoke operation.
+type GetARandomFoodJokeServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*GetARandomFoodJokeResponseData, error)
+}
+
+// GetRandomFoodTriviaServiceRequestOptions holds all parameters for the GetRandomFoodTrivia operation.
+type GetRandomFoodTriviaServiceRequestOptions struct {
+	// RawRequest provides access to the underlying HTTP request for custom content type handling.
+	RawRequest *http.Request
+	// GenerateResponse generates a sample response with random data satisfying the OpenAPI schema.
+	GenerateResponse func() (*GetRandomFoodTriviaResponseData, error)
+}
+
 // generatorService implements ServiceInterface with generator fallback.
 // It delegates to the user's service first; if that returns nil, it generates a mock response.
 type generatorService struct {
@@ -13360,44 +13376,54 @@ func (s *generatorService) SearchFoodVideos(ctx context.Context, opts *SearchFoo
 
 // GetARandomFoodJoke handles GET /food/jokes/random
 func (s *generatorService) GetARandomFoodJoke(ctx context.Context) (*GetARandomFoodJokeResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.GetARandomFoodJoke(ctx); resp != nil || err != nil {
+	opts := &GetARandomFoodJokeServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*GetARandomFoodJokeResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/food/jokes/random", "GET")
+		if respSchema == nil {
+			return NewGetARandomFoodJokeResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		var body GetARandomFoodJokeResponse
+		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
+			return nil, err
+		}
+		return NewGetARandomFoodJokeResponseData(&body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.GetARandomFoodJoke(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/food/jokes/random", "GET")
-	if respSchema == nil {
-		return NewGetARandomFoodJokeResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	var body GetARandomFoodJokeResponse
-	if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
-		return nil, err
-	}
-	return NewGetARandomFoodJokeResponseData(&body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // GetRandomFoodTrivia handles GET /food/trivia/random
 func (s *generatorService) GetRandomFoodTrivia(ctx context.Context) (*GetRandomFoodTriviaResponseData, error) {
-	// Call user's service first
-	if resp, err := s.service.GetRandomFoodTrivia(ctx); resp != nil || err != nil {
+	opts := &GetRandomFoodTriviaServiceRequestOptions{RawRequest: api.RequestFromGoContext(ctx)}
+	// Inject GenerateResponse so user service can call it
+	opts.GenerateResponse = func() (*GetRandomFoodTriviaResponseData, error) {
+		respSchema := s.registry.GetResponseSchema("/food/trivia/random", "GET")
+		if respSchema == nil {
+			return NewGetRandomFoodTriviaResponseData(nil), nil
+		}
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		var body GetRandomFoodTriviaResponse
+		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
+			return nil, err
+		}
+		return NewGetRandomFoodTriviaResponseData(&body).WithHeaders(res.Headers), nil
+	}
+
+	// Call user's service
+	if resp, err := s.service.GetRandomFoodTrivia(ctx, opts); resp != nil || err != nil {
 		return resp, err
 	}
 
 	// Fallback to generator
-	respSchema := s.registry.GetResponseSchema("/food/trivia/random", "GET")
-	if respSchema == nil {
-		return NewGetRandomFoodTriviaResponseData(nil), nil
-	}
-
-	res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
-	var body GetRandomFoodTriviaResponse
-	if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
-		return nil, err
-	}
-	return NewGetRandomFoodTriviaResponseData(&body).WithHeaders(res.Headers), nil
+	return opts.GenerateResponse()
 }
 
 // TalkToChatbot handles GET /food/converse

--- a/examples/docker/pre-generated-services/services/spoonacular/service.go
+++ b/examples/docker/pre-generated-services/services/spoonacular/service.go
@@ -17,9 +17,6 @@ type service struct {
 	params *api.ServiceParams
 }
 
-// Ensure service implements ServiceInterface.
-var _ ServiceInterface = (*service)(nil)
-
 // newService creates a new service instance.
 func newService(params *api.ServiceParams) *service {
 	return &service{params: params}
@@ -691,14 +688,14 @@ func (s *service) SearchFoodVideos(ctx context.Context, opts *SearchFoodVideosSe
 }
 
 // GetARandomFoodJoke handles GET /food/jokes/random
-func (s *service) GetARandomFoodJoke(ctx context.Context) (*GetARandomFoodJokeResponseData, error) {
+func (s *service) GetARandomFoodJoke(ctx context.Context, opts *GetARandomFoodJokeServiceRequestOptions) (*GetARandomFoodJokeResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil
 }
 
 // GetRandomFoodTrivia handles GET /food/trivia/random
-func (s *service) GetRandomFoodTrivia(ctx context.Context) (*GetRandomFoodTriviaResponseData, error) {
+func (s *service) GetRandomFoodTrivia(ctx context.Context, opts *GetRandomFoodTriviaServiceRequestOptions) (*GetRandomFoodTriviaResponseData, error) {
 	// TODO: Implement your business logic here.
 	// Return nil, nil to use the generated mock response.
 	return nil, nil

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -14,7 +14,12 @@ const ContextHeaderName = "X-Mockzilla-Context"
 
 type contextKeyType struct{}
 
-var userContextKey = contextKeyType{}
+type requestContextKeyType struct{}
+
+var (
+	userContextKey    = contextKeyType{}
+	requestContextKey = requestContextKeyType{}
+)
 
 // ExtractContextFromRequest reads and decodes the X-Mockzilla-Context header from an HTTP request.
 // Returns nil if the header is absent or cannot be decoded.
@@ -35,14 +40,15 @@ func ExtractContextFromRequest(r *http.Request) map[string]any {
 }
 
 // ContextReplacementsMiddleware extracts the X-Mockzilla-Context header and stores
-// the decoded context data on the request's Go context.
+// the decoded context data on the request's Go context, along with the request itself.
 func ContextReplacementsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), requestContextKey, r)
 		if ctxData := ExtractContextFromRequest(r); ctxData != nil {
 			slog.Debug("User context from header", "data", ctxData)
-			r = r.WithContext(context.WithValue(r.Context(), userContextKey, ctxData))
+			ctx = context.WithValue(ctx, userContextKey, ctxData)
 		}
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
@@ -50,4 +56,10 @@ func ContextReplacementsMiddleware(next http.Handler) http.Handler {
 func UserContextFromGoContext(ctx context.Context) map[string]any {
 	data, _ := ctx.Value(userContextKey).(map[string]any)
 	return data
+}
+
+// RequestFromGoContext retrieves the HTTP request stored by ContextReplacementsMiddleware.
+func RequestFromGoContext(ctx context.Context) *http.Request {
+	r, _ := ctx.Value(requestContextKey).(*http.Request)
+	return r
 }

--- a/pkg/api/context_test.go
+++ b/pkg/api/context_test.go
@@ -83,6 +83,20 @@ func TestContextReplacementsMiddleware(t *testing.T) {
 		ctx := UserContextFromGoContext(capturedCtx)
 		assert.Equal("active", ctx["status"])
 	})
+
+	t.Run("request stored on context", func(t *testing.T) {
+		var capturedCtx context.Context
+		handler := ContextReplacementsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+		}))
+
+		r := httptest.NewRequest(http.MethodGet, "/pets", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), r)
+
+		stored := RequestFromGoContext(capturedCtx)
+		assert.NotNil(stored)
+		assert.Equal("/pets", stored.URL.Path)
+	})
 }
 
 func TestUserContextFromGoContext(t *testing.T) {
@@ -96,5 +110,19 @@ func TestUserContextFromGoContext(t *testing.T) {
 		data := map[string]any{"foo": "bar"}
 		ctx := context.WithValue(context.Background(), userContextKey, data)
 		assert.Equal(data, UserContextFromGoContext(ctx))
+	})
+}
+
+func TestRequestFromGoContext(t *testing.T) {
+	assert := assert2.New(t)
+
+	t.Run("empty context returns nil", func(t *testing.T) {
+		assert.Nil(RequestFromGoContext(context.Background()))
+	})
+
+	t.Run("returns stored request", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := context.WithValue(context.Background(), requestContextKey, r)
+		assert.Same(r, RequestFromGoContext(ctx))
 	})
 }


### PR DESCRIPTION
## Always pass opts to generated service methods

Every operation in a generated service now receives an options argument, including
endpoints that declare no parameters.

## Why it matters

- **One shape to learn.** Handlers look the same across a whole API, so nothing
  special has to be remembered for the handful of endpoints without parameters.
- **Response generation everywhere.** `opts.GenerateResponse()` is available in
  every handler, so the "generate, then tweak a few fields" workflow works for
  every endpoint instead of most of them.
- **Access to the raw request everywhere.** Handlers can read headers, cookies,
  or the raw body even when the spec declares no parameters, which is common for
  auth headers and other undocumented details.
- **Less friction when specs change.** Adding the first parameter to an endpoint
  no longer changes the handler signature, so existing custom logic keeps
  compiling.

## Upgrade note

Regenerating an existing service requires adding the options argument to handlers
for parameterless endpoints. The compiler points at each one.
