### PR TITLE
Take response values from the incoming request

### DIFF
--- a/cmd/api/templates/handler/chi/handler.tmpl
+++ b/cmd/api/templates/handler/chi/handler.tmpl
@@ -315,7 +315,7 @@ func (s *generatorService) {{ $op.ID }}(ctx context.Context{{ if $op.HasRequestO
 		if respSchema == nil {
 			return {{ $modelsPrefix }}New{{ $op.ID | ucFirst }}ResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		{{- $bodyType := $op.Response.Success.ResponseName -}}
 		{{- if eq $bodyType "struct{}" }}
 		return {{ $modelsPrefix }}New{{ $op.ID | ucFirst }}ResponseData(nil).WithHeaders(res.Headers), nil

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -20,7 +20,7 @@ The context system operates in three phases:
 
 1. **Parse phase**: YAML files are parsed and aliases are extracted
 2. **Alias resolution phase**: All aliases are resolved across namespaces
-3. **Function processing phase**: Function prefixes (`fake:`, `func:`, `botify:`, `join:`) are processed
+3. **Function processing phase**: Function prefixes (`fake:`, `func:`, `botify:`, `join:`, `request:`) are processed
 
 When generating content, the system looks up property names as-is (no case conversion) in the loaded contexts and replaces values accordingly.
 
@@ -228,6 +228,70 @@ expression: "join:-,words.adjectives,words.nouns"  # e.g., "active-account"
 full_name: "join: ,person.first_name,person.last_name"
 ```
 
+### `request:` - Values From the Incoming Request
+
+Takes the value from the body of the request being answered, instead of generating one.
+
+**Syntax:** `request:dotted.path`
+
+```yaml title="payments.yml"
+charge:
+  currency: "request:order.payment.amount.currency"
+  amount: "request:order.payment.amount.value"
+```
+
+A request like:
+
+```json
+{"order": {"payment": {"amount": {"currency": "EUR", "value": 10.5}}}}
+```
+
+produces a response echoing those values:
+
+```json
+{"charge": {"currency": "EUR", "amount": 10.5}}
+```
+
+**Array elements** are addressed by index:
+
+```yaml
+firstCurrency: "request:order.amounts[0].currency"
+secondCurrency: "request:order.amounts[1].currency"
+```
+
+Leaving the index out searches the array and takes the first element where the rest of the
+path resolves, so `request:order.amounts.currency` matches `order.amounts[0].currency` above.
+Top-level arrays are addressed with a leading index: `request:[0].currency`.
+
+**Notes:**
+
+- Only response generation reads the request. During request generation there is nothing to read from.
+- Paths that don't resolve (missing field, index out of range, no request body) fall back to the
+  next matching context, then to normal schema generation. Nothing fails.
+- The value must fit the schema of the property it replaces. A string taken from the request
+  cannot fill an `integer` field; such a value is ignored and the field is generated as usual.
+- Works in area-scoped sections too, e.g. under `in-response` or `in-header`.
+
+**Supported payloads** are picked by the request's `Content-Type` header:
+
+| Content-Type | Read as |
+|---|---|
+| `application/json` (and any `+json`) | JSON |
+| `application/x-www-form-urlencoded` | form fields |
+
+Form bodies are decoded with the same encoding rules mockzilla uses to generate them, so
+paths address nesting and arrays the same way as in JSON:
+
+```
+order[payment][currency]=EUR   →  request:order.payment.currency
+amounts[0][currency]=USD       →  request:amounts[0].currency
+currency=USD&currency=GBP      →  request:currency[1]
+```
+
+Numeric and boolean form values are converted to their JSON types, so they can fill
+`integer`, `number` and `boolean` properties. Other content types (uploads, XML, plain text)
+are not read; refs against them fall back to generated values.
+
 ## Pattern Matching with Dynamic Keys
 
 Context keys can use regex patterns to match multiple property names.
@@ -373,7 +437,7 @@ This is useful for:
 - CI pipelines testing specific values
 - Programmatic response generation with custom data
 
-All context functions (`func:`, `fake:`, `alias:`, `botify:`, `join:`) are supported in the header value - they are processed the same way as context YAML files.
+All context functions (`func:`, `fake:`, `alias:`, `botify:`, `join:`, `request:`) are supported in the header value - they are processed the same way as context YAML files.
 
 ## Performance
 

--- a/examples/commands/service/petstore/gen.go
+++ b/examples/commands/service/petstore/gen.go
@@ -1872,7 +1872,7 @@ func (s *generatorService) UpdatePet(ctx context.Context, opts *UpdatePetService
 		if respSchema == nil {
 			return NewUpdatePetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UpdatePetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1897,7 +1897,7 @@ func (s *generatorService) AddPet(ctx context.Context, opts *AddPetServiceReques
 		if respSchema == nil {
 			return NewAddPetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddPetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1922,7 +1922,7 @@ func (s *generatorService) FindPetsByStatus(ctx context.Context, opts *FindPetsB
 		if respSchema == nil {
 			return NewFindPetsByStatusResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body FindPetsByStatusResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1947,7 +1947,7 @@ func (s *generatorService) FindPetsByTags(ctx context.Context, opts *FindPetsByT
 		if respSchema == nil {
 			return NewFindPetsByTagsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body FindPetsByTagsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1972,7 +1972,7 @@ func (s *generatorService) GetPetByID(ctx context.Context, opts *GetPetByIDServi
 		if respSchema == nil {
 			return NewGetPetByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetPetByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1997,7 +1997,7 @@ func (s *generatorService) UpdatePetWithForm(ctx context.Context, opts *UpdatePe
 		if respSchema == nil {
 			return NewUpdatePetWithFormResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UpdatePetWithFormResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2022,7 +2022,7 @@ func (s *generatorService) DeletePet(ctx context.Context, opts *DeletePetService
 		if respSchema == nil {
 			return NewDeletePetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeletePetResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -2043,7 +2043,7 @@ func (s *generatorService) UploadFile(ctx context.Context, opts *UploadFileServi
 		if respSchema == nil {
 			return NewUploadFileResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UploadFileResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2069,7 +2069,7 @@ func (s *generatorService) GetInventory(ctx context.Context) (*GetInventoryRespo
 		if respSchema == nil {
 			return NewGetInventoryResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetInventoryResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2094,7 +2094,7 @@ func (s *generatorService) PlaceOrder(ctx context.Context, opts *PlaceOrderServi
 		if respSchema == nil {
 			return NewPlaceOrderResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body PlaceOrderResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2119,7 +2119,7 @@ func (s *generatorService) GetOrderByID(ctx context.Context, opts *GetOrderByIDS
 		if respSchema == nil {
 			return NewGetOrderByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetOrderByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2144,7 +2144,7 @@ func (s *generatorService) DeleteOrder(ctx context.Context, opts *DeleteOrderSer
 		if respSchema == nil {
 			return NewDeleteOrderResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeleteOrderResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -2165,7 +2165,7 @@ func (s *generatorService) CreateUser(ctx context.Context, opts *CreateUserServi
 		if respSchema == nil {
 			return NewCreateUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2190,7 +2190,7 @@ func (s *generatorService) CreateUsersWithListInput(ctx context.Context, opts *C
 		if respSchema == nil {
 			return NewCreateUsersWithListInputResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateUsersWithListInputResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2215,7 +2215,7 @@ func (s *generatorService) LoginUser(ctx context.Context, opts *LoginUserService
 		if respSchema == nil {
 			return NewLoginUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body LoginUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2241,7 +2241,7 @@ func (s *generatorService) LogoutUser(ctx context.Context) (*LogoutUserResponseD
 		if respSchema == nil {
 			return NewLogoutUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -2262,7 +2262,7 @@ func (s *generatorService) GetUserByName(ctx context.Context, opts *GetUserByNam
 		if respSchema == nil {
 			return NewGetUserByNameResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetUserByNameResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -2287,7 +2287,7 @@ func (s *generatorService) UpdateUser(ctx context.Context, opts *UpdateUserServi
 		if respSchema == nil {
 			return NewUpdateUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewUpdateUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -2308,7 +2308,7 @@ func (s *generatorService) DeleteUser(ctx context.Context, opts *DeleteUserServi
 		if respSchema == nil {
 			return NewDeleteUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeleteUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 

--- a/examples/commands/service/static/gen.go
+++ b/examples/commands/service/static/gen.go
@@ -396,7 +396,7 @@ func (s *generatorService) PostFooBar(ctx context.Context, opts *PostFooBarServi
 		if respSchema == nil {
 			return NewPostFooBarResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body PostFooBarResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err

--- a/examples/commands/service/users/gen.go
+++ b/examples/commands/service/users/gen.go
@@ -878,7 +878,7 @@ func (s *generatorService) ListUsers(ctx context.Context) (*ListUsersResponseDat
 		if respSchema == nil {
 			return NewListUsersResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ListUsersResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -903,7 +903,7 @@ func (s *generatorService) GetUser(ctx context.Context, opts *GetUserServiceRequ
 		if respSchema == nil {
 			return NewGetUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json; charset=utf-8", &body); err != nil {
 			return nil, err
@@ -928,7 +928,7 @@ func (s *generatorService) GetUserAvatar(ctx context.Context, opts *GetUserAvata
 		if respSchema == nil {
 			return NewGetUserAvatarResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewGetUserAvatarResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -949,7 +949,7 @@ func (s *generatorService) GetUserProfile(ctx context.Context, opts *GetUserProf
 		if respSchema == nil {
 			return NewGetUserProfileResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetUserProfileResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html; charset=utf-8", &body); err != nil {
 			return nil, err
@@ -975,7 +975,7 @@ func (s *generatorService) ExportUsers(ctx context.Context) (*ExportUsersRespons
 		if respSchema == nil {
 			return NewExportUsersResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewExportUsersResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -996,7 +996,7 @@ func (s *generatorService) GetUserConfig(ctx context.Context, opts *GetUserConfi
 		if respSchema == nil {
 			return NewGetUserConfigResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewGetUserConfigResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -1017,7 +1017,7 @@ func (s *generatorService) GetUserAPIData(ctx context.Context, opts *GetUserAPID
 		if respSchema == nil {
 			return NewGetUserAPIDataResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetUserAPIDataResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/vnd.api+json", &body); err != nil {
 			return nil, err
@@ -1042,7 +1042,7 @@ func (s *generatorService) GetUserHal(ctx context.Context, opts *GetUserHalServi
 		if respSchema == nil {
 			return NewGetUserHalResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetUserHalResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/hal+json", &body); err != nil {
 			return nil, err
@@ -1067,7 +1067,7 @@ func (s *generatorService) GetUserProblem(ctx context.Context, opts *GetUserProb
 		if respSchema == nil {
 			return NewGetUserProblemResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetUserProblemResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/problem+json", &body); err != nil {
 			return nil, err
@@ -1093,7 +1093,7 @@ func (s *generatorService) StreamUsers(ctx context.Context) (*StreamUsersRespons
 		if respSchema == nil {
 			return NewStreamUsersResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewStreamUsersResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -1114,7 +1114,7 @@ func (s *generatorService) GetUserPdf(ctx context.Context, opts *GetUserPdfServi
 		if respSchema == nil {
 			return NewGetUserPdfResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewGetUserPdfResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 

--- a/examples/docker-compose/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/petstore/gen.go
@@ -1453,7 +1453,7 @@ func (s *generatorService) UpdatePet(ctx context.Context, opts *UpdatePetService
 		if respSchema == nil {
 			return NewUpdatePetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UpdatePetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1478,7 +1478,7 @@ func (s *generatorService) AddPet(ctx context.Context, opts *AddPetServiceReques
 		if respSchema == nil {
 			return NewAddPetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddPetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1503,7 +1503,7 @@ func (s *generatorService) FindPetsByStatus(ctx context.Context, opts *FindPetsB
 		if respSchema == nil {
 			return NewFindPetsByStatusResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body FindPetsByStatusResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1528,7 +1528,7 @@ func (s *generatorService) FindPetsByTags(ctx context.Context, opts *FindPetsByT
 		if respSchema == nil {
 			return NewFindPetsByTagsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body FindPetsByTagsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1553,7 +1553,7 @@ func (s *generatorService) GetPetByID(ctx context.Context, opts *GetPetByIDServi
 		if respSchema == nil {
 			return NewGetPetByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetPetByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1578,7 +1578,7 @@ func (s *generatorService) UpdatePetWithForm(ctx context.Context, opts *UpdatePe
 		if respSchema == nil {
 			return NewUpdatePetWithFormResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UpdatePetWithFormResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1603,7 +1603,7 @@ func (s *generatorService) DeletePet(ctx context.Context, opts *DeletePetService
 		if respSchema == nil {
 			return NewDeletePetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeletePetResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -1624,7 +1624,7 @@ func (s *generatorService) UploadFile(ctx context.Context, opts *UploadFileServi
 		if respSchema == nil {
 			return NewUploadFileResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UploadFileResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1650,7 +1650,7 @@ func (s *generatorService) GetInventory(ctx context.Context) (*GetInventoryRespo
 		if respSchema == nil {
 			return NewGetInventoryResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetInventoryResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1675,7 +1675,7 @@ func (s *generatorService) PlaceOrder(ctx context.Context, opts *PlaceOrderServi
 		if respSchema == nil {
 			return NewPlaceOrderResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body PlaceOrderResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1700,7 +1700,7 @@ func (s *generatorService) GetOrderByID(ctx context.Context, opts *GetOrderByIDS
 		if respSchema == nil {
 			return NewGetOrderByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetOrderByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1725,7 +1725,7 @@ func (s *generatorService) DeleteOrder(ctx context.Context, opts *DeleteOrderSer
 		if respSchema == nil {
 			return NewDeleteOrderResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeleteOrderResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -1746,7 +1746,7 @@ func (s *generatorService) CreateUser(ctx context.Context, opts *CreateUserServi
 		if respSchema == nil {
 			return NewCreateUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1771,7 +1771,7 @@ func (s *generatorService) CreateUsersWithListInput(ctx context.Context, opts *C
 		if respSchema == nil {
 			return NewCreateUsersWithListInputResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateUsersWithListInputResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1796,7 +1796,7 @@ func (s *generatorService) LoginUser(ctx context.Context, opts *LoginUserService
 		if respSchema == nil {
 			return NewLoginUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body LoginUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1822,7 +1822,7 @@ func (s *generatorService) LogoutUser(ctx context.Context) (*LogoutUserResponseD
 		if respSchema == nil {
 			return NewLogoutUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -1843,7 +1843,7 @@ func (s *generatorService) GetUserByName(ctx context.Context, opts *GetUserByNam
 		if respSchema == nil {
 			return NewGetUserByNameResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetUserByNameResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1868,7 +1868,7 @@ func (s *generatorService) UpdateUser(ctx context.Context, opts *UpdateUserServi
 		if respSchema == nil {
 			return NewUpdateUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewUpdateUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -1889,7 +1889,7 @@ func (s *generatorService) DeleteUser(ctx context.Context, opts *DeleteUserServi
 		if respSchema == nil {
 			return NewDeleteUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeleteUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 

--- a/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
@@ -11047,7 +11047,7 @@ func (s *generatorService) SearchRecipes(ctx context.Context, opts *SearchRecipe
 		if respSchema == nil {
 			return NewSearchRecipesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchRecipesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11072,7 +11072,7 @@ func (s *generatorService) SearchRecipesByIngredients(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewSearchRecipesByIngredientsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchRecipesByIngredientsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11097,7 +11097,7 @@ func (s *generatorService) SearchRecipesByNutrients(ctx context.Context, opts *S
 		if respSchema == nil {
 			return NewSearchRecipesByNutrientsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchRecipesByNutrientsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11122,7 +11122,7 @@ func (s *generatorService) GetRecipeInformation(ctx context.Context, opts *GetRe
 		if respSchema == nil {
 			return NewGetRecipeInformationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeInformationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11147,7 +11147,7 @@ func (s *generatorService) GetRecipeInformationBulk(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGetRecipeInformationBulkResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeInformationBulkResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11172,7 +11172,7 @@ func (s *generatorService) GetSimilarRecipes(ctx context.Context, opts *GetSimil
 		if respSchema == nil {
 			return NewGetSimilarRecipesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetSimilarRecipesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11197,7 +11197,7 @@ func (s *generatorService) GetRandomRecipes(ctx context.Context, opts *GetRandom
 		if respSchema == nil {
 			return NewGetRandomRecipesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRandomRecipesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11222,7 +11222,7 @@ func (s *generatorService) AutocompleteRecipeSearch(ctx context.Context, opts *A
 		if respSchema == nil {
 			return NewAutocompleteRecipeSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AutocompleteRecipeSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11247,7 +11247,7 @@ func (s *generatorService) GetRecipeTasteByID(ctx context.Context, opts *GetReci
 		if respSchema == nil {
 			return NewGetRecipeTasteByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeTasteByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11272,7 +11272,7 @@ func (s *generatorService) RecipeTasteByIDImage(ctx context.Context, opts *Recip
 		if respSchema == nil {
 			return NewRecipeTasteByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewRecipeTasteByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11293,7 +11293,7 @@ func (s *generatorService) GetRecipeEquipmentByID(ctx context.Context, opts *Get
 		if respSchema == nil {
 			return NewGetRecipeEquipmentByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeEquipmentByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11318,7 +11318,7 @@ func (s *generatorService) EquipmentByIDImage(ctx context.Context, opts *Equipme
 		if respSchema == nil {
 			return NewEquipmentByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewEquipmentByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11339,7 +11339,7 @@ func (s *generatorService) GetRecipePriceBreakdownByID(ctx context.Context, opts
 		if respSchema == nil {
 			return NewGetRecipePriceBreakdownByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipePriceBreakdownByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11364,7 +11364,7 @@ func (s *generatorService) PriceBreakdownByIDImage(ctx context.Context, opts *Pr
 		if respSchema == nil {
 			return NewPriceBreakdownByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewPriceBreakdownByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11385,7 +11385,7 @@ func (s *generatorService) GetRecipeIngredientsByID(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGetRecipeIngredientsByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeIngredientsByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11410,7 +11410,7 @@ func (s *generatorService) IngredientsByIDImage(ctx context.Context, opts *Ingre
 		if respSchema == nil {
 			return NewIngredientsByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewIngredientsByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11431,7 +11431,7 @@ func (s *generatorService) GetRecipeNutritionWidgetByID(ctx context.Context, opt
 		if respSchema == nil {
 			return NewGetRecipeNutritionWidgetByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeNutritionWidgetByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11456,7 +11456,7 @@ func (s *generatorService) RecipeNutritionByIDImage(ctx context.Context, opts *R
 		if respSchema == nil {
 			return NewRecipeNutritionByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewRecipeNutritionByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11477,7 +11477,7 @@ func (s *generatorService) RecipeNutritionLabelWidget(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewRecipeNutritionLabelWidgetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body RecipeNutritionLabelWidgetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11502,7 +11502,7 @@ func (s *generatorService) RecipeNutritionLabelImage(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewRecipeNutritionLabelImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewRecipeNutritionLabelImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11523,7 +11523,7 @@ func (s *generatorService) GetAnalyzedRecipeInstructions(ctx context.Context, op
 		if respSchema == nil {
 			return NewGetAnalyzedRecipeInstructionsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetAnalyzedRecipeInstructionsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11548,7 +11548,7 @@ func (s *generatorService) ExtractRecipeFromWebsite(ctx context.Context, opts *E
 		if respSchema == nil {
 			return NewExtractRecipeFromWebsiteResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ExtractRecipeFromWebsiteResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11573,7 +11573,7 @@ func (s *generatorService) VisualizeRecipeIngredientsByID(ctx context.Context, o
 		if respSchema == nil {
 			return NewVisualizeRecipeIngredientsByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeIngredientsByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11598,7 +11598,7 @@ func (s *generatorService) VisualizeRecipeTasteByID(ctx context.Context, opts *V
 		if respSchema == nil {
 			return NewVisualizeRecipeTasteByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeTasteByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11623,7 +11623,7 @@ func (s *generatorService) VisualizeRecipeEquipmentByID(ctx context.Context, opt
 		if respSchema == nil {
 			return NewVisualizeRecipeEquipmentByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeEquipmentByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11648,7 +11648,7 @@ func (s *generatorService) VisualizeRecipePriceBreakdownByID(ctx context.Context
 		if respSchema == nil {
 			return NewVisualizeRecipePriceBreakdownByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipePriceBreakdownByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11673,7 +11673,7 @@ func (s *generatorService) VisualizeRecipeTaste(ctx context.Context, opts *Visua
 		if respSchema == nil {
 			return NewVisualizeRecipeTasteResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeTasteResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11698,7 +11698,7 @@ func (s *generatorService) VisualizeRecipeNutrition(ctx context.Context, opts *V
 		if respSchema == nil {
 			return NewVisualizeRecipeNutritionResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeNutritionResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11723,7 +11723,7 @@ func (s *generatorService) VisualizePriceBreakdown(ctx context.Context, opts *Vi
 		if respSchema == nil {
 			return NewVisualizePriceBreakdownResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizePriceBreakdownResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11748,7 +11748,7 @@ func (s *generatorService) VisualizeEquipment(ctx context.Context, opts *Visuali
 		if respSchema == nil {
 			return NewVisualizeEquipmentResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeEquipmentResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11773,7 +11773,7 @@ func (s *generatorService) AnalyzeRecipe(ctx context.Context, opts *AnalyzeRecip
 		if respSchema == nil {
 			return NewAnalyzeRecipeResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AnalyzeRecipeResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11798,7 +11798,7 @@ func (s *generatorService) SummarizeRecipe(ctx context.Context, opts *SummarizeR
 		if respSchema == nil {
 			return NewSummarizeRecipeResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SummarizeRecipeResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11823,7 +11823,7 @@ func (s *generatorService) CreateRecipeCardGet(ctx context.Context, opts *Create
 		if respSchema == nil {
 			return NewCreateRecipeCardGetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateRecipeCardGetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11848,7 +11848,7 @@ func (s *generatorService) CreateRecipeCard(ctx context.Context, opts *CreateRec
 		if respSchema == nil {
 			return NewCreateRecipeCardResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateRecipeCardResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11873,7 +11873,7 @@ func (s *generatorService) AnalyzeRecipeInstructions(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewAnalyzeRecipeInstructionsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AnalyzeRecipeInstructionsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11898,7 +11898,7 @@ func (s *generatorService) ClassifyCuisine(ctx context.Context, opts *ClassifyCu
 		if respSchema == nil {
 			return NewClassifyCuisineResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ClassifyCuisineResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11923,7 +11923,7 @@ func (s *generatorService) AnalyzeARecipeSearchQuery(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewAnalyzeARecipeSearchQueryResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AnalyzeARecipeSearchQueryResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11948,7 +11948,7 @@ func (s *generatorService) ConvertAmounts(ctx context.Context, opts *ConvertAmou
 		if respSchema == nil {
 			return NewConvertAmountsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ConvertAmountsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11973,7 +11973,7 @@ func (s *generatorService) ParseIngredients(ctx context.Context, opts *ParseIngr
 		if respSchema == nil {
 			return NewParseIngredientsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ParseIngredientsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11998,7 +11998,7 @@ func (s *generatorService) VisualizeRecipeNutritionByID(ctx context.Context, opt
 		if respSchema == nil {
 			return NewVisualizeRecipeNutritionByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeNutritionByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12023,7 +12023,7 @@ func (s *generatorService) VisualizeIngredients(ctx context.Context, opts *Visua
 		if respSchema == nil {
 			return NewVisualizeIngredientsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeIngredientsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12048,7 +12048,7 @@ func (s *generatorService) GuessNutritionByDishName(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGuessNutritionByDishNameResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GuessNutritionByDishNameResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12073,7 +12073,7 @@ func (s *generatorService) GetIngredientInformation(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGetIngredientInformationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetIngredientInformationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12098,7 +12098,7 @@ func (s *generatorService) ComputeIngredientAmount(ctx context.Context, opts *Co
 		if respSchema == nil {
 			return NewComputeIngredientAmountResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ComputeIngredientAmountResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12123,7 +12123,7 @@ func (s *generatorService) ComputeGlycemicLoad(ctx context.Context, opts *Comput
 		if respSchema == nil {
 			return NewComputeGlycemicLoadResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ComputeGlycemicLoadResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12148,7 +12148,7 @@ func (s *generatorService) AutocompleteIngredientSearch(ctx context.Context, opt
 		if respSchema == nil {
 			return NewAutocompleteIngredientSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AutocompleteIngredientSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12173,7 +12173,7 @@ func (s *generatorService) IngredientSearch(ctx context.Context, opts *Ingredien
 		if respSchema == nil {
 			return NewIngredientSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body IngredientSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12198,7 +12198,7 @@ func (s *generatorService) GetIngredientSubstitutes(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGetIngredientSubstitutesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetIngredientSubstitutesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12223,7 +12223,7 @@ func (s *generatorService) GetIngredientSubstitutesByID(ctx context.Context, opt
 		if respSchema == nil {
 			return NewGetIngredientSubstitutesByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetIngredientSubstitutesByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12248,7 +12248,7 @@ func (s *generatorService) SearchGroceryProducts(ctx context.Context, opts *Sear
 		if respSchema == nil {
 			return NewSearchGroceryProductsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchGroceryProductsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12273,7 +12273,7 @@ func (s *generatorService) SearchGroceryProductsByUPC(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewSearchGroceryProductsByUPCResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchGroceryProductsByUPCResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12298,7 +12298,7 @@ func (s *generatorService) SearchCustomFoods(ctx context.Context, opts *SearchCu
 		if respSchema == nil {
 			return NewSearchCustomFoodsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchCustomFoodsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12323,7 +12323,7 @@ func (s *generatorService) GetProductInformation(ctx context.Context, opts *GetP
 		if respSchema == nil {
 			return NewGetProductInformationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetProductInformationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12348,7 +12348,7 @@ func (s *generatorService) GetComparableProducts(ctx context.Context, opts *GetC
 		if respSchema == nil {
 			return NewGetComparableProductsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetComparableProductsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12373,7 +12373,7 @@ func (s *generatorService) AutocompleteProductSearch(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewAutocompleteProductSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AutocompleteProductSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12398,7 +12398,7 @@ func (s *generatorService) VisualizeProductNutritionByID(ctx context.Context, op
 		if respSchema == nil {
 			return NewVisualizeProductNutritionByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeProductNutritionByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12423,7 +12423,7 @@ func (s *generatorService) ProductNutritionByIDImage(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewProductNutritionByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewProductNutritionByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -12444,7 +12444,7 @@ func (s *generatorService) ProductNutritionLabelWidget(ctx context.Context, opts
 		if respSchema == nil {
 			return NewProductNutritionLabelWidgetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ProductNutritionLabelWidgetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12469,7 +12469,7 @@ func (s *generatorService) ProductNutritionLabelImage(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewProductNutritionLabelImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewProductNutritionLabelImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -12490,7 +12490,7 @@ func (s *generatorService) ClassifyGroceryProduct(ctx context.Context, opts *Cla
 		if respSchema == nil {
 			return NewClassifyGroceryProductResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ClassifyGroceryProductResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12515,7 +12515,7 @@ func (s *generatorService) ClassifyGroceryProductBulk(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewClassifyGroceryProductBulkResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ClassifyGroceryProductBulkResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12540,7 +12540,7 @@ func (s *generatorService) MapIngredientsToGroceryProducts(ctx context.Context, 
 		if respSchema == nil {
 			return NewMapIngredientsToGroceryProductsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body MapIngredientsToGroceryProductsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12565,7 +12565,7 @@ func (s *generatorService) AutocompleteMenuItemSearch(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewAutocompleteMenuItemSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AutocompleteMenuItemSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12590,7 +12590,7 @@ func (s *generatorService) SearchMenuItems(ctx context.Context, opts *SearchMenu
 		if respSchema == nil {
 			return NewSearchMenuItemsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchMenuItemsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12615,7 +12615,7 @@ func (s *generatorService) GetMenuItemInformation(ctx context.Context, opts *Get
 		if respSchema == nil {
 			return NewGetMenuItemInformationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetMenuItemInformationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12640,7 +12640,7 @@ func (s *generatorService) VisualizeMenuItemNutritionByID(ctx context.Context, o
 		if respSchema == nil {
 			return NewVisualizeMenuItemNutritionByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeMenuItemNutritionByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12665,7 +12665,7 @@ func (s *generatorService) MenuItemNutritionByIDImage(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewMenuItemNutritionByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewMenuItemNutritionByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -12686,7 +12686,7 @@ func (s *generatorService) MenuItemNutritionLabelWidget(ctx context.Context, opt
 		if respSchema == nil {
 			return NewMenuItemNutritionLabelWidgetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body MenuItemNutritionLabelWidgetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12711,7 +12711,7 @@ func (s *generatorService) MenuItemNutritionLabelImage(ctx context.Context, opts
 		if respSchema == nil {
 			return NewMenuItemNutritionLabelImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewMenuItemNutritionLabelImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -12732,7 +12732,7 @@ func (s *generatorService) GenerateMealPlan(ctx context.Context, opts *GenerateM
 		if respSchema == nil {
 			return NewGenerateMealPlanResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GenerateMealPlanResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12757,7 +12757,7 @@ func (s *generatorService) GetMealPlanWeek(ctx context.Context, opts *GetMealPla
 		if respSchema == nil {
 			return NewGetMealPlanWeekResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetMealPlanWeekResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12782,7 +12782,7 @@ func (s *generatorService) ClearMealPlanDay(ctx context.Context, opts *ClearMeal
 		if respSchema == nil {
 			return NewClearMealPlanDayResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ClearMealPlanDayResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12807,7 +12807,7 @@ func (s *generatorService) AddToMealPlan(ctx context.Context, opts *AddToMealPla
 		if respSchema == nil {
 			return NewAddToMealPlanResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddToMealPlanResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12832,7 +12832,7 @@ func (s *generatorService) DeleteFromMealPlan(ctx context.Context, opts *DeleteF
 		if respSchema == nil {
 			return NewDeleteFromMealPlanResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body DeleteFromMealPlanResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12857,7 +12857,7 @@ func (s *generatorService) GetMealPlanTemplates(ctx context.Context, opts *GetMe
 		if respSchema == nil {
 			return NewGetMealPlanTemplatesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetMealPlanTemplatesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12882,7 +12882,7 @@ func (s *generatorService) AddMealPlanTemplate(ctx context.Context, opts *AddMea
 		if respSchema == nil {
 			return NewAddMealPlanTemplateResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddMealPlanTemplateResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12907,7 +12907,7 @@ func (s *generatorService) GetMealPlanTemplate(ctx context.Context, opts *GetMea
 		if respSchema == nil {
 			return NewGetMealPlanTemplateResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetMealPlanTemplateResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12932,7 +12932,7 @@ func (s *generatorService) DeleteMealPlanTemplate(ctx context.Context, opts *Del
 		if respSchema == nil {
 			return NewDeleteMealPlanTemplateResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body DeleteMealPlanTemplateResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12957,7 +12957,7 @@ func (s *generatorService) GetShoppingList(ctx context.Context, opts *GetShoppin
 		if respSchema == nil {
 			return NewGetShoppingListResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetShoppingListResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12982,7 +12982,7 @@ func (s *generatorService) GenerateShoppingList(ctx context.Context, opts *Gener
 		if respSchema == nil {
 			return NewGenerateShoppingListResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GenerateShoppingListResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13007,7 +13007,7 @@ func (s *generatorService) ConnectUser(ctx context.Context, opts *ConnectUserSer
 		if respSchema == nil {
 			return NewConnectUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ConnectUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13032,7 +13032,7 @@ func (s *generatorService) AddToShoppingList(ctx context.Context, opts *AddToSho
 		if respSchema == nil {
 			return NewAddToShoppingListResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddToShoppingListResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13057,7 +13057,7 @@ func (s *generatorService) DeleteFromShoppingList(ctx context.Context, opts *Del
 		if respSchema == nil {
 			return NewDeleteFromShoppingListResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body DeleteFromShoppingListResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13082,7 +13082,7 @@ func (s *generatorService) SearchRestaurants(ctx context.Context, opts *SearchRe
 		if respSchema == nil {
 			return NewSearchRestaurantsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchRestaurantsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13107,7 +13107,7 @@ func (s *generatorService) GetDishPairingForWine(ctx context.Context, opts *GetD
 		if respSchema == nil {
 			return NewGetDishPairingForWineResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetDishPairingForWineResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13132,7 +13132,7 @@ func (s *generatorService) GetWinePairing(ctx context.Context, opts *GetWinePair
 		if respSchema == nil {
 			return NewGetWinePairingResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetWinePairingResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13157,7 +13157,7 @@ func (s *generatorService) GetWineDescription(ctx context.Context, opts *GetWine
 		if respSchema == nil {
 			return NewGetWineDescriptionResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetWineDescriptionResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13182,7 +13182,7 @@ func (s *generatorService) GetWineRecommendation(ctx context.Context, opts *GetW
 		if respSchema == nil {
 			return NewGetWineRecommendationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetWineRecommendationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13207,7 +13207,7 @@ func (s *generatorService) ImageClassificationByURL(ctx context.Context, opts *I
 		if respSchema == nil {
 			return NewImageClassificationByURLResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ImageClassificationByURLResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13232,7 +13232,7 @@ func (s *generatorService) ImageAnalysisByURL(ctx context.Context, opts *ImageAn
 		if respSchema == nil {
 			return NewImageAnalysisByURLResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ImageAnalysisByURLResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13257,7 +13257,7 @@ func (s *generatorService) QuickAnswer(ctx context.Context, opts *QuickAnswerSer
 		if respSchema == nil {
 			return NewQuickAnswerResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body QuickAnswerResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13282,7 +13282,7 @@ func (s *generatorService) DetectFoodInText(ctx context.Context, opts *DetectFoo
 		if respSchema == nil {
 			return NewDetectFoodInTextResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body DetectFoodInTextResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13307,7 +13307,7 @@ func (s *generatorService) SearchSiteContent(ctx context.Context, opts *SearchSi
 		if respSchema == nil {
 			return NewSearchSiteContentResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchSiteContentResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13332,7 +13332,7 @@ func (s *generatorService) SearchAllFood(ctx context.Context, opts *SearchAllFoo
 		if respSchema == nil {
 			return NewSearchAllFoodResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchAllFoodResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13357,7 +13357,7 @@ func (s *generatorService) SearchFoodVideos(ctx context.Context, opts *SearchFoo
 		if respSchema == nil {
 			return NewSearchFoodVideosResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchFoodVideosResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13383,7 +13383,7 @@ func (s *generatorService) GetARandomFoodJoke(ctx context.Context) (*GetARandomF
 		if respSchema == nil {
 			return NewGetARandomFoodJokeResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetARandomFoodJokeResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13409,7 +13409,7 @@ func (s *generatorService) GetRandomFoodTrivia(ctx context.Context) (*GetRandomF
 		if respSchema == nil {
 			return NewGetRandomFoodTriviaResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRandomFoodTriviaResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13434,7 +13434,7 @@ func (s *generatorService) TalkToChatbot(ctx context.Context, opts *TalkToChatbo
 		if respSchema == nil {
 			return NewTalkToChatbotResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body TalkToChatbotResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13459,7 +13459,7 @@ func (s *generatorService) GetConversationSuggests(ctx context.Context, opts *Ge
 		if respSchema == nil {
 			return NewGetConversationSuggestsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetConversationSuggestsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err

--- a/examples/docker/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker/pre-generated-services/services/petstore/gen.go
@@ -1453,7 +1453,7 @@ func (s *generatorService) UpdatePet(ctx context.Context, opts *UpdatePetService
 		if respSchema == nil {
 			return NewUpdatePetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UpdatePetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1478,7 +1478,7 @@ func (s *generatorService) AddPet(ctx context.Context, opts *AddPetServiceReques
 		if respSchema == nil {
 			return NewAddPetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddPetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1503,7 +1503,7 @@ func (s *generatorService) FindPetsByStatus(ctx context.Context, opts *FindPetsB
 		if respSchema == nil {
 			return NewFindPetsByStatusResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body FindPetsByStatusResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1528,7 +1528,7 @@ func (s *generatorService) FindPetsByTags(ctx context.Context, opts *FindPetsByT
 		if respSchema == nil {
 			return NewFindPetsByTagsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body FindPetsByTagsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1553,7 +1553,7 @@ func (s *generatorService) GetPetByID(ctx context.Context, opts *GetPetByIDServi
 		if respSchema == nil {
 			return NewGetPetByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetPetByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1578,7 +1578,7 @@ func (s *generatorService) UpdatePetWithForm(ctx context.Context, opts *UpdatePe
 		if respSchema == nil {
 			return NewUpdatePetWithFormResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UpdatePetWithFormResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1603,7 +1603,7 @@ func (s *generatorService) DeletePet(ctx context.Context, opts *DeletePetService
 		if respSchema == nil {
 			return NewDeletePetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeletePetResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -1624,7 +1624,7 @@ func (s *generatorService) UploadFile(ctx context.Context, opts *UploadFileServi
 		if respSchema == nil {
 			return NewUploadFileResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body UploadFileResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1650,7 +1650,7 @@ func (s *generatorService) GetInventory(ctx context.Context) (*GetInventoryRespo
 		if respSchema == nil {
 			return NewGetInventoryResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetInventoryResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1675,7 +1675,7 @@ func (s *generatorService) PlaceOrder(ctx context.Context, opts *PlaceOrderServi
 		if respSchema == nil {
 			return NewPlaceOrderResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body PlaceOrderResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1700,7 +1700,7 @@ func (s *generatorService) GetOrderByID(ctx context.Context, opts *GetOrderByIDS
 		if respSchema == nil {
 			return NewGetOrderByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetOrderByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1725,7 +1725,7 @@ func (s *generatorService) DeleteOrder(ctx context.Context, opts *DeleteOrderSer
 		if respSchema == nil {
 			return NewDeleteOrderResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeleteOrderResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -1746,7 +1746,7 @@ func (s *generatorService) CreateUser(ctx context.Context, opts *CreateUserServi
 		if respSchema == nil {
 			return NewCreateUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1771,7 +1771,7 @@ func (s *generatorService) CreateUsersWithListInput(ctx context.Context, opts *C
 		if respSchema == nil {
 			return NewCreateUsersWithListInputResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateUsersWithListInputResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1796,7 +1796,7 @@ func (s *generatorService) LoginUser(ctx context.Context, opts *LoginUserService
 		if respSchema == nil {
 			return NewLoginUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body LoginUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1822,7 +1822,7 @@ func (s *generatorService) LogoutUser(ctx context.Context) (*LogoutUserResponseD
 		if respSchema == nil {
 			return NewLogoutUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewLogoutUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -1843,7 +1843,7 @@ func (s *generatorService) GetUserByName(ctx context.Context, opts *GetUserByNam
 		if respSchema == nil {
 			return NewGetUserByNameResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetUserByNameResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -1868,7 +1868,7 @@ func (s *generatorService) UpdateUser(ctx context.Context, opts *UpdateUserServi
 		if respSchema == nil {
 			return NewUpdateUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewUpdateUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 
@@ -1889,7 +1889,7 @@ func (s *generatorService) DeleteUser(ctx context.Context, opts *DeleteUserServi
 		if respSchema == nil {
 			return NewDeleteUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewDeleteUserResponseData(nil).WithHeaders(res.Headers), nil
 	}
 

--- a/examples/docker/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker/pre-generated-services/services/spoonacular/gen.go
@@ -11047,7 +11047,7 @@ func (s *generatorService) SearchRecipes(ctx context.Context, opts *SearchRecipe
 		if respSchema == nil {
 			return NewSearchRecipesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchRecipesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11072,7 +11072,7 @@ func (s *generatorService) SearchRecipesByIngredients(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewSearchRecipesByIngredientsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchRecipesByIngredientsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11097,7 +11097,7 @@ func (s *generatorService) SearchRecipesByNutrients(ctx context.Context, opts *S
 		if respSchema == nil {
 			return NewSearchRecipesByNutrientsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchRecipesByNutrientsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11122,7 +11122,7 @@ func (s *generatorService) GetRecipeInformation(ctx context.Context, opts *GetRe
 		if respSchema == nil {
 			return NewGetRecipeInformationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeInformationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11147,7 +11147,7 @@ func (s *generatorService) GetRecipeInformationBulk(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGetRecipeInformationBulkResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeInformationBulkResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11172,7 +11172,7 @@ func (s *generatorService) GetSimilarRecipes(ctx context.Context, opts *GetSimil
 		if respSchema == nil {
 			return NewGetSimilarRecipesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetSimilarRecipesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11197,7 +11197,7 @@ func (s *generatorService) GetRandomRecipes(ctx context.Context, opts *GetRandom
 		if respSchema == nil {
 			return NewGetRandomRecipesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRandomRecipesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11222,7 +11222,7 @@ func (s *generatorService) AutocompleteRecipeSearch(ctx context.Context, opts *A
 		if respSchema == nil {
 			return NewAutocompleteRecipeSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AutocompleteRecipeSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11247,7 +11247,7 @@ func (s *generatorService) GetRecipeTasteByID(ctx context.Context, opts *GetReci
 		if respSchema == nil {
 			return NewGetRecipeTasteByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeTasteByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11272,7 +11272,7 @@ func (s *generatorService) RecipeTasteByIDImage(ctx context.Context, opts *Recip
 		if respSchema == nil {
 			return NewRecipeTasteByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewRecipeTasteByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11293,7 +11293,7 @@ func (s *generatorService) GetRecipeEquipmentByID(ctx context.Context, opts *Get
 		if respSchema == nil {
 			return NewGetRecipeEquipmentByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeEquipmentByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11318,7 +11318,7 @@ func (s *generatorService) EquipmentByIDImage(ctx context.Context, opts *Equipme
 		if respSchema == nil {
 			return NewEquipmentByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewEquipmentByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11339,7 +11339,7 @@ func (s *generatorService) GetRecipePriceBreakdownByID(ctx context.Context, opts
 		if respSchema == nil {
 			return NewGetRecipePriceBreakdownByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipePriceBreakdownByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11364,7 +11364,7 @@ func (s *generatorService) PriceBreakdownByIDImage(ctx context.Context, opts *Pr
 		if respSchema == nil {
 			return NewPriceBreakdownByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewPriceBreakdownByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11385,7 +11385,7 @@ func (s *generatorService) GetRecipeIngredientsByID(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGetRecipeIngredientsByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeIngredientsByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11410,7 +11410,7 @@ func (s *generatorService) IngredientsByIDImage(ctx context.Context, opts *Ingre
 		if respSchema == nil {
 			return NewIngredientsByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewIngredientsByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11431,7 +11431,7 @@ func (s *generatorService) GetRecipeNutritionWidgetByID(ctx context.Context, opt
 		if respSchema == nil {
 			return NewGetRecipeNutritionWidgetByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRecipeNutritionWidgetByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11456,7 +11456,7 @@ func (s *generatorService) RecipeNutritionByIDImage(ctx context.Context, opts *R
 		if respSchema == nil {
 			return NewRecipeNutritionByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewRecipeNutritionByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11477,7 +11477,7 @@ func (s *generatorService) RecipeNutritionLabelWidget(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewRecipeNutritionLabelWidgetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body RecipeNutritionLabelWidgetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11502,7 +11502,7 @@ func (s *generatorService) RecipeNutritionLabelImage(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewRecipeNutritionLabelImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewRecipeNutritionLabelImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -11523,7 +11523,7 @@ func (s *generatorService) GetAnalyzedRecipeInstructions(ctx context.Context, op
 		if respSchema == nil {
 			return NewGetAnalyzedRecipeInstructionsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetAnalyzedRecipeInstructionsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11548,7 +11548,7 @@ func (s *generatorService) ExtractRecipeFromWebsite(ctx context.Context, opts *E
 		if respSchema == nil {
 			return NewExtractRecipeFromWebsiteResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ExtractRecipeFromWebsiteResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11573,7 +11573,7 @@ func (s *generatorService) VisualizeRecipeIngredientsByID(ctx context.Context, o
 		if respSchema == nil {
 			return NewVisualizeRecipeIngredientsByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeIngredientsByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11598,7 +11598,7 @@ func (s *generatorService) VisualizeRecipeTasteByID(ctx context.Context, opts *V
 		if respSchema == nil {
 			return NewVisualizeRecipeTasteByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeTasteByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11623,7 +11623,7 @@ func (s *generatorService) VisualizeRecipeEquipmentByID(ctx context.Context, opt
 		if respSchema == nil {
 			return NewVisualizeRecipeEquipmentByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeEquipmentByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11648,7 +11648,7 @@ func (s *generatorService) VisualizeRecipePriceBreakdownByID(ctx context.Context
 		if respSchema == nil {
 			return NewVisualizeRecipePriceBreakdownByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipePriceBreakdownByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11673,7 +11673,7 @@ func (s *generatorService) VisualizeRecipeTaste(ctx context.Context, opts *Visua
 		if respSchema == nil {
 			return NewVisualizeRecipeTasteResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeTasteResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11698,7 +11698,7 @@ func (s *generatorService) VisualizeRecipeNutrition(ctx context.Context, opts *V
 		if respSchema == nil {
 			return NewVisualizeRecipeNutritionResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeNutritionResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11723,7 +11723,7 @@ func (s *generatorService) VisualizePriceBreakdown(ctx context.Context, opts *Vi
 		if respSchema == nil {
 			return NewVisualizePriceBreakdownResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizePriceBreakdownResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11748,7 +11748,7 @@ func (s *generatorService) VisualizeEquipment(ctx context.Context, opts *Visuali
 		if respSchema == nil {
 			return NewVisualizeEquipmentResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeEquipmentResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -11773,7 +11773,7 @@ func (s *generatorService) AnalyzeRecipe(ctx context.Context, opts *AnalyzeRecip
 		if respSchema == nil {
 			return NewAnalyzeRecipeResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AnalyzeRecipeResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11798,7 +11798,7 @@ func (s *generatorService) SummarizeRecipe(ctx context.Context, opts *SummarizeR
 		if respSchema == nil {
 			return NewSummarizeRecipeResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SummarizeRecipeResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11823,7 +11823,7 @@ func (s *generatorService) CreateRecipeCardGet(ctx context.Context, opts *Create
 		if respSchema == nil {
 			return NewCreateRecipeCardGetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateRecipeCardGetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11848,7 +11848,7 @@ func (s *generatorService) CreateRecipeCard(ctx context.Context, opts *CreateRec
 		if respSchema == nil {
 			return NewCreateRecipeCardResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body CreateRecipeCardResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11873,7 +11873,7 @@ func (s *generatorService) AnalyzeRecipeInstructions(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewAnalyzeRecipeInstructionsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AnalyzeRecipeInstructionsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11898,7 +11898,7 @@ func (s *generatorService) ClassifyCuisine(ctx context.Context, opts *ClassifyCu
 		if respSchema == nil {
 			return NewClassifyCuisineResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ClassifyCuisineResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11923,7 +11923,7 @@ func (s *generatorService) AnalyzeARecipeSearchQuery(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewAnalyzeARecipeSearchQueryResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AnalyzeARecipeSearchQueryResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11948,7 +11948,7 @@ func (s *generatorService) ConvertAmounts(ctx context.Context, opts *ConvertAmou
 		if respSchema == nil {
 			return NewConvertAmountsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ConvertAmountsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11973,7 +11973,7 @@ func (s *generatorService) ParseIngredients(ctx context.Context, opts *ParseIngr
 		if respSchema == nil {
 			return NewParseIngredientsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ParseIngredientsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -11998,7 +11998,7 @@ func (s *generatorService) VisualizeRecipeNutritionByID(ctx context.Context, opt
 		if respSchema == nil {
 			return NewVisualizeRecipeNutritionByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeRecipeNutritionByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12023,7 +12023,7 @@ func (s *generatorService) VisualizeIngredients(ctx context.Context, opts *Visua
 		if respSchema == nil {
 			return NewVisualizeIngredientsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeIngredientsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12048,7 +12048,7 @@ func (s *generatorService) GuessNutritionByDishName(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGuessNutritionByDishNameResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GuessNutritionByDishNameResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12073,7 +12073,7 @@ func (s *generatorService) GetIngredientInformation(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGetIngredientInformationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetIngredientInformationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12098,7 +12098,7 @@ func (s *generatorService) ComputeIngredientAmount(ctx context.Context, opts *Co
 		if respSchema == nil {
 			return NewComputeIngredientAmountResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ComputeIngredientAmountResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12123,7 +12123,7 @@ func (s *generatorService) ComputeGlycemicLoad(ctx context.Context, opts *Comput
 		if respSchema == nil {
 			return NewComputeGlycemicLoadResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ComputeGlycemicLoadResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12148,7 +12148,7 @@ func (s *generatorService) AutocompleteIngredientSearch(ctx context.Context, opt
 		if respSchema == nil {
 			return NewAutocompleteIngredientSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AutocompleteIngredientSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12173,7 +12173,7 @@ func (s *generatorService) IngredientSearch(ctx context.Context, opts *Ingredien
 		if respSchema == nil {
 			return NewIngredientSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body IngredientSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12198,7 +12198,7 @@ func (s *generatorService) GetIngredientSubstitutes(ctx context.Context, opts *G
 		if respSchema == nil {
 			return NewGetIngredientSubstitutesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetIngredientSubstitutesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12223,7 +12223,7 @@ func (s *generatorService) GetIngredientSubstitutesByID(ctx context.Context, opt
 		if respSchema == nil {
 			return NewGetIngredientSubstitutesByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetIngredientSubstitutesByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12248,7 +12248,7 @@ func (s *generatorService) SearchGroceryProducts(ctx context.Context, opts *Sear
 		if respSchema == nil {
 			return NewSearchGroceryProductsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchGroceryProductsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12273,7 +12273,7 @@ func (s *generatorService) SearchGroceryProductsByUPC(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewSearchGroceryProductsByUPCResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchGroceryProductsByUPCResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12298,7 +12298,7 @@ func (s *generatorService) SearchCustomFoods(ctx context.Context, opts *SearchCu
 		if respSchema == nil {
 			return NewSearchCustomFoodsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchCustomFoodsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12323,7 +12323,7 @@ func (s *generatorService) GetProductInformation(ctx context.Context, opts *GetP
 		if respSchema == nil {
 			return NewGetProductInformationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetProductInformationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12348,7 +12348,7 @@ func (s *generatorService) GetComparableProducts(ctx context.Context, opts *GetC
 		if respSchema == nil {
 			return NewGetComparableProductsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetComparableProductsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12373,7 +12373,7 @@ func (s *generatorService) AutocompleteProductSearch(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewAutocompleteProductSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AutocompleteProductSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12398,7 +12398,7 @@ func (s *generatorService) VisualizeProductNutritionByID(ctx context.Context, op
 		if respSchema == nil {
 			return NewVisualizeProductNutritionByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeProductNutritionByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12423,7 +12423,7 @@ func (s *generatorService) ProductNutritionByIDImage(ctx context.Context, opts *
 		if respSchema == nil {
 			return NewProductNutritionByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewProductNutritionByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -12444,7 +12444,7 @@ func (s *generatorService) ProductNutritionLabelWidget(ctx context.Context, opts
 		if respSchema == nil {
 			return NewProductNutritionLabelWidgetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ProductNutritionLabelWidgetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12469,7 +12469,7 @@ func (s *generatorService) ProductNutritionLabelImage(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewProductNutritionLabelImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewProductNutritionLabelImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -12490,7 +12490,7 @@ func (s *generatorService) ClassifyGroceryProduct(ctx context.Context, opts *Cla
 		if respSchema == nil {
 			return NewClassifyGroceryProductResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ClassifyGroceryProductResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12515,7 +12515,7 @@ func (s *generatorService) ClassifyGroceryProductBulk(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewClassifyGroceryProductBulkResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ClassifyGroceryProductBulkResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12540,7 +12540,7 @@ func (s *generatorService) MapIngredientsToGroceryProducts(ctx context.Context, 
 		if respSchema == nil {
 			return NewMapIngredientsToGroceryProductsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body MapIngredientsToGroceryProductsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12565,7 +12565,7 @@ func (s *generatorService) AutocompleteMenuItemSearch(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewAutocompleteMenuItemSearchResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AutocompleteMenuItemSearchResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12590,7 +12590,7 @@ func (s *generatorService) SearchMenuItems(ctx context.Context, opts *SearchMenu
 		if respSchema == nil {
 			return NewSearchMenuItemsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchMenuItemsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12615,7 +12615,7 @@ func (s *generatorService) GetMenuItemInformation(ctx context.Context, opts *Get
 		if respSchema == nil {
 			return NewGetMenuItemInformationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetMenuItemInformationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12640,7 +12640,7 @@ func (s *generatorService) VisualizeMenuItemNutritionByID(ctx context.Context, o
 		if respSchema == nil {
 			return NewVisualizeMenuItemNutritionByIDResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body VisualizeMenuItemNutritionByIDResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12665,7 +12665,7 @@ func (s *generatorService) MenuItemNutritionByIDImage(ctx context.Context, opts 
 		if respSchema == nil {
 			return NewMenuItemNutritionByIDImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewMenuItemNutritionByIDImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -12686,7 +12686,7 @@ func (s *generatorService) MenuItemNutritionLabelWidget(ctx context.Context, opt
 		if respSchema == nil {
 			return NewMenuItemNutritionLabelWidgetResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body MenuItemNutritionLabelWidgetResponse
 		if err := api.UnmarshalResponseInto(res.Body, "text/html", &body); err != nil {
 			return nil, err
@@ -12711,7 +12711,7 @@ func (s *generatorService) MenuItemNutritionLabelImage(ctx context.Context, opts
 		if respSchema == nil {
 			return NewMenuItemNutritionLabelImageResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		return NewMenuItemNutritionLabelImageResponseData(res.Body).WithHeaders(res.Headers), nil
 	}
 
@@ -12732,7 +12732,7 @@ func (s *generatorService) GenerateMealPlan(ctx context.Context, opts *GenerateM
 		if respSchema == nil {
 			return NewGenerateMealPlanResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GenerateMealPlanResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12757,7 +12757,7 @@ func (s *generatorService) GetMealPlanWeek(ctx context.Context, opts *GetMealPla
 		if respSchema == nil {
 			return NewGetMealPlanWeekResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetMealPlanWeekResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12782,7 +12782,7 @@ func (s *generatorService) ClearMealPlanDay(ctx context.Context, opts *ClearMeal
 		if respSchema == nil {
 			return NewClearMealPlanDayResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ClearMealPlanDayResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12807,7 +12807,7 @@ func (s *generatorService) AddToMealPlan(ctx context.Context, opts *AddToMealPla
 		if respSchema == nil {
 			return NewAddToMealPlanResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddToMealPlanResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12832,7 +12832,7 @@ func (s *generatorService) DeleteFromMealPlan(ctx context.Context, opts *DeleteF
 		if respSchema == nil {
 			return NewDeleteFromMealPlanResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body DeleteFromMealPlanResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12857,7 +12857,7 @@ func (s *generatorService) GetMealPlanTemplates(ctx context.Context, opts *GetMe
 		if respSchema == nil {
 			return NewGetMealPlanTemplatesResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetMealPlanTemplatesResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12882,7 +12882,7 @@ func (s *generatorService) AddMealPlanTemplate(ctx context.Context, opts *AddMea
 		if respSchema == nil {
 			return NewAddMealPlanTemplateResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddMealPlanTemplateResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12907,7 +12907,7 @@ func (s *generatorService) GetMealPlanTemplate(ctx context.Context, opts *GetMea
 		if respSchema == nil {
 			return NewGetMealPlanTemplateResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetMealPlanTemplateResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12932,7 +12932,7 @@ func (s *generatorService) DeleteMealPlanTemplate(ctx context.Context, opts *Del
 		if respSchema == nil {
 			return NewDeleteMealPlanTemplateResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body DeleteMealPlanTemplateResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12957,7 +12957,7 @@ func (s *generatorService) GetShoppingList(ctx context.Context, opts *GetShoppin
 		if respSchema == nil {
 			return NewGetShoppingListResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetShoppingListResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -12982,7 +12982,7 @@ func (s *generatorService) GenerateShoppingList(ctx context.Context, opts *Gener
 		if respSchema == nil {
 			return NewGenerateShoppingListResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GenerateShoppingListResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13007,7 +13007,7 @@ func (s *generatorService) ConnectUser(ctx context.Context, opts *ConnectUserSer
 		if respSchema == nil {
 			return NewConnectUserResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ConnectUserResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13032,7 +13032,7 @@ func (s *generatorService) AddToShoppingList(ctx context.Context, opts *AddToSho
 		if respSchema == nil {
 			return NewAddToShoppingListResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body AddToShoppingListResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13057,7 +13057,7 @@ func (s *generatorService) DeleteFromShoppingList(ctx context.Context, opts *Del
 		if respSchema == nil {
 			return NewDeleteFromShoppingListResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body DeleteFromShoppingListResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13082,7 +13082,7 @@ func (s *generatorService) SearchRestaurants(ctx context.Context, opts *SearchRe
 		if respSchema == nil {
 			return NewSearchRestaurantsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchRestaurantsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13107,7 +13107,7 @@ func (s *generatorService) GetDishPairingForWine(ctx context.Context, opts *GetD
 		if respSchema == nil {
 			return NewGetDishPairingForWineResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetDishPairingForWineResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13132,7 +13132,7 @@ func (s *generatorService) GetWinePairing(ctx context.Context, opts *GetWinePair
 		if respSchema == nil {
 			return NewGetWinePairingResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetWinePairingResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13157,7 +13157,7 @@ func (s *generatorService) GetWineDescription(ctx context.Context, opts *GetWine
 		if respSchema == nil {
 			return NewGetWineDescriptionResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetWineDescriptionResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13182,7 +13182,7 @@ func (s *generatorService) GetWineRecommendation(ctx context.Context, opts *GetW
 		if respSchema == nil {
 			return NewGetWineRecommendationResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetWineRecommendationResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13207,7 +13207,7 @@ func (s *generatorService) ImageClassificationByURL(ctx context.Context, opts *I
 		if respSchema == nil {
 			return NewImageClassificationByURLResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ImageClassificationByURLResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13232,7 +13232,7 @@ func (s *generatorService) ImageAnalysisByURL(ctx context.Context, opts *ImageAn
 		if respSchema == nil {
 			return NewImageAnalysisByURLResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body ImageAnalysisByURLResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13257,7 +13257,7 @@ func (s *generatorService) QuickAnswer(ctx context.Context, opts *QuickAnswerSer
 		if respSchema == nil {
 			return NewQuickAnswerResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body QuickAnswerResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13282,7 +13282,7 @@ func (s *generatorService) DetectFoodInText(ctx context.Context, opts *DetectFoo
 		if respSchema == nil {
 			return NewDetectFoodInTextResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body DetectFoodInTextResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13307,7 +13307,7 @@ func (s *generatorService) SearchSiteContent(ctx context.Context, opts *SearchSi
 		if respSchema == nil {
 			return NewSearchSiteContentResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchSiteContentResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13332,7 +13332,7 @@ func (s *generatorService) SearchAllFood(ctx context.Context, opts *SearchAllFoo
 		if respSchema == nil {
 			return NewSearchAllFoodResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchAllFoodResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13357,7 +13357,7 @@ func (s *generatorService) SearchFoodVideos(ctx context.Context, opts *SearchFoo
 		if respSchema == nil {
 			return NewSearchFoodVideosResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body SearchFoodVideosResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13383,7 +13383,7 @@ func (s *generatorService) GetARandomFoodJoke(ctx context.Context) (*GetARandomF
 		if respSchema == nil {
 			return NewGetARandomFoodJokeResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetARandomFoodJokeResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13409,7 +13409,7 @@ func (s *generatorService) GetRandomFoodTrivia(ctx context.Context) (*GetRandomF
 		if respSchema == nil {
 			return NewGetRandomFoodTriviaResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetRandomFoodTriviaResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13434,7 +13434,7 @@ func (s *generatorService) TalkToChatbot(ctx context.Context, opts *TalkToChatbo
 		if respSchema == nil {
 			return NewTalkToChatbotResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body TalkToChatbotResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err
@@ -13459,7 +13459,7 @@ func (s *generatorService) GetConversationSuggests(ctx context.Context, opts *Ge
 		if respSchema == nil {
 			return NewGetConversationSuggestsResponseData(nil), nil
 		}
-		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx))
+		res := s.generator.Response(respSchema, api.UserContextFromGoContext(ctx), generator.WithRequest(api.RequestFromGoContext(ctx)))
 		var body GetConversationSuggestsResponse
 		if err := api.UnmarshalResponseInto(res.Body, "application/json", &body); err != nil {
 			return nil, err

--- a/internal/contexts/parsers.go
+++ b/internal/contexts/parsers.go
@@ -15,7 +15,7 @@ import (
 // The function operates in three phases:
 //  1. Parse phase: Parses YAML files and extracts aliases and raw data
 //  2. Alias resolution phase: Resolves all aliases across namespaces
-//  3. function processing phase: Processes function prefixes (fake, func, botify, join)
+//  3. function processing phase: Processes function prefixes (fake, func, botify, join, request)
 //
 // Parameters:
 //   - files: Map of namespace names to YAML file contents
@@ -34,6 +34,7 @@ import (
 //   - func:name:arg1,arg2 - Calls a registered function with two arguments (e.g., func:int_between:1,10)
 //   - botify:pattern - Generates random strings based on pattern (? for letter, # for digit)
 //   - join:separator,ns.key1,ns.key2 - Joins values from multiple keys with separator
+//   - request:dotted.path - Takes the value from the incoming request payload
 //
 // Example:
 //
@@ -175,6 +176,10 @@ func processFunctions(allResults map[string]map[string]any, ctx map[string]any) 
 				res, ok = parseJoinContextFunc(parts, convertedResult)
 				if ok {
 					ctx[key] = res
+				}
+			case "request":
+				if path := v[len(RequestPrefix):]; path != "" {
+					ctx[key] = RequestRef{Path: path}
 				}
 			}
 		case map[string]any:

--- a/internal/contexts/parsers_test.go
+++ b/internal/contexts/parsers_test.go
@@ -239,6 +239,23 @@ fullname: "join:,ns1.first,ns1.second"`),
 		assert2.Regexp(t, "^[a-z]{3}[0-9]{3}$", val)
 	})
 
+	t.Run("request reference", func(t *testing.T) {
+		res := Load(map[string][]byte{
+			"ns1": []byte(`currency: "request:order.payment.amount.currency"
+charge:
+  currency: "request:order.amounts[0].currency"
+empty: "request:"`),
+		}, nil)
+
+		assert2.Equal(t, RequestRef{Path: "order.payment.amount.currency"}, res["ns1"]["currency"])
+		assert2.Equal(t,
+			RequestRef{Path: "order.amounts[0].currency"},
+			res["ns1"]["charge"].(map[string]any)["currency"])
+
+		// nothing to resolve, kept as-is so the mistake is visible in the output
+		assert2.Equal(t, "request:", res["ns1"]["empty"])
+	})
+
 	t.Run("nested fake functions", func(t *testing.T) {
 		res := Load(map[string][]byte{
 			"fake": []byte(`

--- a/internal/contexts/request.go
+++ b/internal/contexts/request.go
@@ -1,0 +1,37 @@
+package contexts
+
+// RequestPrefix marks a context value that is taken from the incoming request
+// payload instead of being generated, e.g. `request:order.payment.currency`.
+const RequestPrefix = "request:"
+
+// RequestRef is the parsed form of a `request:` context value. It carries the
+// dotted path into the request payload; the value itself can only be resolved
+// per request, during generation.
+type RequestRef struct {
+	Path string
+}
+
+// HasRequestRefs reports whether any of the given contexts contains a RequestRef.
+// Callers use it to skip reading and parsing request payloads nobody references.
+func HasRequestRefs(data []map[string]any) bool {
+	for _, ctx := range data {
+		if mapHasRequestRef(ctx) {
+			return true
+		}
+	}
+	return false
+}
+
+func mapHasRequestRef(ctx map[string]any) bool {
+	for _, value := range ctx {
+		switch v := value.(type) {
+		case RequestRef:
+			return true
+		case map[string]any:
+			if mapHasRequestRef(v) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/contexts/request_test.go
+++ b/internal/contexts/request_test.go
@@ -1,0 +1,41 @@
+package contexts
+
+import (
+	"testing"
+
+	assert2 "github.com/stretchr/testify/assert"
+)
+
+func TestHasRequestRefs(t *testing.T) {
+	assert := assert2.New(t)
+	t.Parallel()
+
+	t.Run("no contexts", func(t *testing.T) {
+		assert.False(HasRequestRefs(nil))
+	})
+
+	t.Run("without refs", func(t *testing.T) {
+		assert.False(HasRequestRefs([]map[string]any{
+			{"name": "Jane", "nested": map[string]any{"id": 1}},
+		}))
+	})
+
+	t.Run("root level ref", func(t *testing.T) {
+		assert.True(HasRequestRefs([]map[string]any{
+			{"name": "Jane"},
+			{"currency": RequestRef{Path: "order.currency"}},
+		}))
+	})
+
+	t.Run("nested ref", func(t *testing.T) {
+		assert.True(HasRequestRefs([]map[string]any{
+			{
+				"in-response": map[string]any{
+					"charge": map[string]any{
+						"currency": RequestRef{Path: "order.currency"},
+					},
+				},
+			},
+		}))
+	})
+}

--- a/internal/portable/handler.go
+++ b/internal/portable/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/mockzilla/mockzilla/v2/pkg/api"
 	"github.com/mockzilla/mockzilla/v2/pkg/factory"
+	"github.com/mockzilla/mockzilla/v2/pkg/generator"
 	validator "github.com/pb33f/libopenapi-validator"
 )
 
@@ -100,7 +101,7 @@ func (h *handler) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.factory.Response(specPath, r.Method, ctx)
+	resp, err := h.factory.Response(specPath, r.Method, ctx, generator.WithRequest(r))
 	if err != nil {
 		slog.Debug("Failed to generate response", "method", r.Method, "path", specPath, "error", err)
 		http.Error(w, fmt.Sprintf("failed to generate response: %s %s", r.Method, endpointPath), http.StatusInternalServerError)

--- a/internal/portable/handler_test.go
+++ b/internal/portable/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/mockzilla/mockzilla/v2/pkg/api"
 	"github.com/mockzilla/mockzilla/v2/pkg/config"
+	"github.com/mockzilla/mockzilla/v2/pkg/factory"
 	"github.com/mockzilla/mockzilla/v2/pkg/schema"
 	validator "github.com/pb33f/libopenapi-validator"
 	"github.com/stretchr/testify/assert"
@@ -116,6 +117,47 @@ func TestHandler_handleRequest(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.True(t, json.Valid(w.Body.Bytes()))
+	})
+}
+
+func TestHandler_handleRequest_requestContext(t *testing.T) {
+	specBytes := loadTestSpec(t, "petstore.yml")
+	h, err := newHandler(specBytes, factory.WithServiceContext([]byte(`
+name: "request:pets[0].name"
+id: "request:order.id"
+`)))
+	require.NoError(t, err)
+
+	r := chi.NewRouter()
+	h.RegisterRoutes(r)
+
+	post := func(contentType, body string) map[string]any {
+		req := httptest.NewRequest(http.MethodPost, "/pets", strings.NewReader(body))
+		req.Header.Set("Content-Type", contentType)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		var res map[string]any
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+		return res
+	}
+
+	t.Run("response takes values from the json request body", func(t *testing.T) {
+		res := post("application/json", `{"pets":[{"name":"Rex"}],"order":{"id":42}}`)
+		assert.Equal(t, "Rex", res["name"])
+		assert.Equal(t, float64(42), res["id"])
+	})
+
+	t.Run("response takes values from the form request body", func(t *testing.T) {
+		res := post("application/x-www-form-urlencoded", "pets[0][name]=Rex&order[id]=42")
+		assert.Equal(t, "Rex", res["name"])
+		assert.Equal(t, float64(42), res["id"])
+	})
+
+	t.Run("unresolved paths fall back to generated values", func(t *testing.T) {
+		res := post("application/json", `{}`)
+		assert.NotEmpty(t, res["name"])
+		assert.NotEqual(t, "Rex", res["name"])
 	})
 }
 

--- a/internal/replacer/impl.go
+++ b/internal/replacer/impl.go
@@ -245,7 +245,8 @@ func replaceInArea(ctx *ReplaceContext, area string) any {
 			continue
 		}
 
-		if res := replaceValueWithContext(ctx.state.NamePath, replacements); res != nil {
+		res := replaceValueWithContext(ctx.state.NamePath, replacements)
+		if res = resolveRequestRef(ctx, res); res != nil {
 			return res
 		}
 	}
@@ -256,20 +257,50 @@ func replaceInArea(ctx *ReplaceContext, area string) any {
 // replaceFromContext is a replacer that replaces values from the context.
 func replaceFromContext(ctx *ReplaceContext) any {
 	for _, data := range ctx.data {
-		if res := replaceValueWithContext(ctx.state.NamePath, data); res != nil {
-			v := castToSchemaFormat(ctx, res)
+		res := replaceValueWithContext(ctx.state.NamePath, data)
 
-			// If context returned empty string, return nil to let other replacers handle it
-			// This avoids validation errors for required string fields
-			if str, ok := v.(string); ok && str == "" {
-				return nil
+		// A request reference names its target field outright, so it skips the
+		// format filtering castToSchemaFormat applies to guessed context values.
+		// Values that don't fit the schema are dropped by the caller anyway.
+		if _, isRef := res.(contexts.RequestRef); isRef {
+			if res = resolveRequestRef(ctx, res); res == nil {
+				continue
 			}
-
-			return v
+			return res
 		}
+
+		if res == nil {
+			continue
+		}
+
+		v := castToSchemaFormat(ctx, res)
+
+		// If context returned empty string, return nil to let other replacers handle it
+		// This avoids validation errors for required string fields
+		if str, ok := v.(string); ok && str == "" {
+			return nil
+		}
+
+		return v
 	}
 
 	return nil
+}
+
+// resolveRequestRef resolves a `request:` context value against the payload of
+// the incoming request. Non-ref values pass through untouched; a ref that
+// doesn't resolve returns nil so the remaining contexts and replacers apply.
+func resolveRequestRef(ctx *ReplaceContext, value any) any {
+	ref, ok := value.(contexts.RequestRef)
+	if !ok {
+		return value
+	}
+
+	if ctx.state == nil || ctx.state.RequestPayload == nil {
+		return nil
+	}
+
+	return types.GetValueByJSONPath(ctx.state.RequestPayload, ref.Path)
 }
 
 // castToSchemaFormat casts the value to the schema format if possible.
@@ -336,6 +367,10 @@ func replaceValueWithContext(path []string, contextData any) interface{} {
 	// base cases below:
 	case contexts.FakeFunc:
 		return valueType().Get()
+
+	// resolved by the caller, which has access to the request payload
+	case contexts.RequestRef:
+		return valueType
 
 	case string, int, bool, float64:
 		return valueType

--- a/internal/replacer/impl_test.go
+++ b/internal/replacer/impl_test.go
@@ -4,6 +4,7 @@ package replacer
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"net"
 	"strconv"
 	"strings"
@@ -272,6 +273,24 @@ func TestReplaceInResponse(t *testing.T) {
 			},
 		})
 		assert.Equal(100, res)
+	})
+
+	t.Run("request-ref-in-response-area", func(t *testing.T) {
+		state := NewReplaceState(WithName("currency"), WithReadOnly(),
+			WithRequestPayload(testRequestPayload(t)))
+		res := replaceInResponse(&ReplaceContext{
+			faker:      fake,
+			state:      state,
+			areaPrefix: "in-",
+			data: []map[string]any{
+				{
+					"in-response": map[string]any{
+						"currency": contexts.RequestRef{Path: "order.payment.amount.currency"},
+					},
+				},
+			},
+		})
+		assert.Equal("EUR", res)
 	})
 
 	t.Run("falls-through-when-no-match", func(t *testing.T) {
@@ -694,6 +713,104 @@ func TestReplaceFromContext(t *testing.T) {
 		})
 		assert.Nil(res)
 	})
+
+	t.Run("request-ref-resolved-from-payload", func(t *testing.T) {
+		s := &schema.Schema{Type: types.TypeString}
+		state := NewReplaceStateWithName("charge").WithOptions(
+			WithName("currency"),
+			WithRequestPayload(testRequestPayload(t)))
+
+		res := replaceFromContext(&ReplaceContext{
+			faker:  fake,
+			schema: s,
+			state:  state,
+			data: []map[string]any{
+				{
+					"charge": map[string]any{
+						"currency": contexts.RequestRef{Path: "order.payment.amount.currency"},
+					},
+				},
+			},
+		})
+		assert.Equal("EUR", res)
+	})
+
+	t.Run("request-ref-fills-uuid-format", func(t *testing.T) {
+		s := &schema.Schema{Type: types.TypeString, Format: "uuid"}
+		state := NewReplaceStateWithName("id").WithOptions(
+			WithRequestPayload(map[string]any{"id": "550e8400-e29b-41d4-a716-446655440000"}))
+
+		res := replaceFromContext(&ReplaceContext{
+			faker:  fake,
+			schema: s,
+			state:  state,
+			data: []map[string]any{
+				{"id": contexts.RequestRef{Path: "id"}},
+			},
+		})
+		assert.Equal("550e8400-e29b-41d4-a716-446655440000", res)
+	})
+
+	t.Run("request-ref-falls-through-to-next-context", func(t *testing.T) {
+		s := &schema.Schema{Type: types.TypeString}
+		state := NewReplaceStateWithName("currency").WithOptions(
+			WithRequestPayload(testRequestPayload(t)))
+
+		res := replaceFromContext(&ReplaceContext{
+			faker:  fake,
+			schema: s,
+			state:  state,
+			data: []map[string]any{
+				{"currency": contexts.RequestRef{Path: "order.missing.currency"}},
+				{"currency": "USD"},
+			},
+		})
+		assert.Equal("USD", res)
+	})
+}
+
+func TestResolveRequestRef(t *testing.T) {
+	assert := assert2.New(t)
+
+	t.Run("non-ref-value-passes-through", func(t *testing.T) {
+		ctx := &ReplaceContext{state: NewReplaceState()}
+		assert.Equal("USD", resolveRequestRef(ctx, "USD"))
+		assert.Nil(resolveRequestRef(ctx, nil))
+	})
+
+	t.Run("no-payload", func(t *testing.T) {
+		ctx := &ReplaceContext{state: NewReplaceState()}
+		assert.Nil(resolveRequestRef(ctx, contexts.RequestRef{Path: "order.id"}))
+	})
+
+	t.Run("dotted-path", func(t *testing.T) {
+		ctx := &ReplaceContext{state: NewReplaceState(WithRequestPayload(testRequestPayload(t)))}
+		assert.Equal("EUR", resolveRequestRef(ctx, contexts.RequestRef{Path: "order.payment.amount.currency"}))
+		assert.Equal(10.5, resolveRequestRef(ctx, contexts.RequestRef{Path: "order.payment.amount.value"}))
+	})
+
+	t.Run("array-index", func(t *testing.T) {
+		ctx := &ReplaceContext{state: NewReplaceState(WithRequestPayload(testRequestPayload(t)))}
+		assert.Equal("USD", resolveRequestRef(ctx, contexts.RequestRef{Path: "order.amounts[0].currency"}))
+		assert.Equal("GBP", resolveRequestRef(ctx, contexts.RequestRef{Path: "order.amounts[1].currency"}))
+		assert.Nil(resolveRequestRef(ctx, contexts.RequestRef{Path: "order.amounts[9].currency"}))
+	})
+}
+
+func testRequestPayload(t *testing.T) any {
+	t.Helper()
+
+	var payload any
+	err := json.Unmarshal([]byte(`{
+		"order": {
+			"payment": {"amount": {"currency": "EUR", "value": 10.5}},
+			"amounts": [{"currency": "USD"}, {"currency": "GBP"}]
+		}
+	}`), &payload)
+	if err != nil {
+		t.Fatalf("invalid test payload: %v", err)
+	}
+	return payload
 }
 
 func TestCastToSchemaFormat(t *testing.T) {

--- a/internal/replacer/state.go
+++ b/internal/replacer/state.go
@@ -27,6 +27,9 @@ import (
 // RecursionHit is set to true when a circular reference is detected during generation.
 // This allows parent objects to know that a child returned nil due to recursion,
 // not because it was legitimately optional.
+//
+// RequestPayload is the decoded body of the incoming request, used to resolve
+// `request:` context values. It is nil when no request is available.
 type ReplaceState struct {
 	NamePath           []string
 	ElementIndex       int
@@ -37,6 +40,7 @@ type ReplaceState struct {
 	IsContentWriteOnly bool
 	SchemaStack        map[*schema.Schema]bool
 	RecursionHit       bool
+	RequestPayload     any
 	mu                 sync.Mutex
 }
 
@@ -64,6 +68,7 @@ func (s *ReplaceState) NewFrom(src *ReplaceState) *ReplaceState {
 		ContentType:        src.ContentType,
 		IsContentReadOnly:  src.IsContentReadOnly,
 		IsContentWriteOnly: src.IsContentWriteOnly,
+		RequestPayload:     src.RequestPayload,
 
 		// Share the same map to track recursion across the tree
 		SchemaStack: src.SchemaStack,
@@ -127,5 +132,11 @@ func WithReadOnly() ReplaceStateOption {
 func WithWriteOnly() ReplaceStateOption {
 	return func(state *ReplaceState) {
 		state.IsContentWriteOnly = true
+	}
+}
+
+func WithRequestPayload(value any) ReplaceStateOption {
+	return func(state *ReplaceState) {
+		state.RequestPayload = value
 	}
 }

--- a/internal/types/jsonpath.go
+++ b/internal/types/jsonpath.go
@@ -1,0 +1,119 @@
+package types
+
+import (
+	"strconv"
+	"strings"
+)
+
+// PathSegment represents a single segment in a dotted path.
+type PathSegment struct {
+	Key   string
+	Index int  // -1 means no index
+	IsArr bool // true if this segment has an array index like [0]
+}
+
+// ParseDottedPath splits a dotted path into segments.
+// "data.items[0].name" → [{Key:"data"}, {Key:"items", Index:0, IsArr:true}, {Key:"name"}]
+// "[0].name"           → [{Key:"", Index:0, IsArr:true}, {Key:"name"}]
+func ParseDottedPath(path string) []PathSegment {
+	parts := strings.Split(path, ".")
+	segments := make([]PathSegment, 0, len(parts))
+
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		if idx := strings.Index(part, "["); idx != -1 {
+			key := part[:idx]
+			indexStr := strings.TrimSuffix(part[idx+1:], "]")
+			index, err := strconv.Atoi(indexStr)
+			if err != nil {
+				// Invalid index, treat as plain key
+				segments = append(segments, PathSegment{Key: part, Index: -1})
+				continue
+			}
+			segments = append(segments, PathSegment{Key: key, Index: index, IsArr: true})
+		} else {
+			segments = append(segments, PathSegment{Key: part, Index: -1})
+		}
+	}
+
+	return segments
+}
+
+// GetValueByJSONPath returns the value at the given dotted path in already
+// decoded JSON data. Returns nil when the path doesn't resolve.
+// Supports:
+//   - Simple: "data.name" - traverse nested objects
+//   - Array index: "data.items[0].name" - specific element
+//   - Array wildcard: "data.items.name" - when items is an array, search each element
+//   - Top-level array: "[0].name" - index into a root-level array
+func GetValueByJSONPath(data any, path string) any {
+	return navigatePath(data, ParseDottedPath(path))
+}
+
+// navigatePath traverses the decoded JSON structure following the path segments.
+func navigatePath(current any, segments []PathSegment) any {
+	for i, seg := range segments {
+		if current == nil {
+			return nil
+		}
+
+		// Handle array at current level (top-level or bare index after traversal)
+		if arr, ok := current.([]any); ok {
+			if seg.IsArr && seg.Key == "" {
+				// Bare index like [0] - index directly into the current array
+				if seg.Index < 0 || seg.Index >= len(arr) {
+					return nil
+				}
+				current = arr[seg.Index]
+				continue
+			}
+			// Array wildcard - search each element with remaining segments
+			remaining := segments[i:]
+			for _, elem := range arr {
+				result := navigatePath(elem, remaining)
+				if result != nil {
+					return result
+				}
+			}
+			return nil
+		}
+
+		switch v := current.(type) {
+		case map[string]any:
+			val, ok := v[seg.Key]
+			if !ok {
+				return nil
+			}
+
+			if seg.IsArr {
+				// Need to index into an array
+				arr, ok := val.([]any)
+				if !ok || seg.Index < 0 || seg.Index >= len(arr) {
+					return nil
+				}
+				current = arr[seg.Index]
+			} else {
+				// Check if val is an array and we have more segments - wildcard search
+				if arr, ok := val.([]any); ok && i+1 < len(segments) {
+					remaining := segments[i+1:]
+					for _, elem := range arr {
+						result := navigatePath(elem, remaining)
+						if result != nil {
+							return result
+						}
+					}
+					return nil
+				}
+				current = val
+			}
+
+		default:
+			return nil
+		}
+	}
+
+	return current
+}

--- a/internal/types/jsonpath_test.go
+++ b/internal/types/jsonpath_test.go
@@ -1,0 +1,106 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	assert2 "github.com/stretchr/testify/assert"
+)
+
+func TestParseDottedPath(t *testing.T) {
+	assert := assert2.New(t)
+
+	t.Run("simple path", func(t *testing.T) {
+		segments := ParseDottedPath("data.name")
+		assert.Len(segments, 2)
+		assert.Equal("data", segments[0].Key)
+		assert.Equal(-1, segments[0].Index)
+		assert.Equal("name", segments[1].Key)
+	})
+
+	t.Run("array index", func(t *testing.T) {
+		segments := ParseDottedPath("data.items[0].name")
+		assert.Len(segments, 3)
+		assert.Equal("items", segments[1].Key)
+		assert.Equal(0, segments[1].Index)
+		assert.True(segments[1].IsArr)
+	})
+
+	t.Run("invalid array index treated as key", func(t *testing.T) {
+		segments := ParseDottedPath("data.items[abc].name")
+		assert.Len(segments, 3)
+		assert.Equal("items[abc]", segments[1].Key)
+		assert.Equal(-1, segments[1].Index)
+		assert.False(segments[1].IsArr)
+	})
+
+	t.Run("bare array index", func(t *testing.T) {
+		segments := ParseDottedPath("[0].name")
+		assert.Len(segments, 2)
+		assert.Equal("", segments[0].Key)
+		assert.Equal(0, segments[0].Index)
+		assert.True(segments[0].IsArr)
+		assert.Equal("name", segments[1].Key)
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		segments := ParseDottedPath("")
+		assert.Empty(segments)
+	})
+}
+
+func TestGetValueByJSONPath(t *testing.T) {
+	assert := assert2.New(t)
+
+	decode := func(src string) any {
+		var res any
+		if err := json.Unmarshal([]byte(src), &res); err != nil {
+			t.Fatalf("invalid test json: %v", err)
+		}
+		return res
+	}
+
+	data := decode(`{
+		"order": {
+			"payment": {"amount": {"currency": "EUR", "value": 10.5}},
+			"amounts": [
+				{"currency": "USD"},
+				{"currency": "GBP"}
+			],
+			"paid": true
+		}
+	}`)
+
+	tests := []struct {
+		name     string
+		path     string
+		expected any
+	}{
+		{"nested object", "order.payment.amount.currency", "EUR"},
+		{"number value", "order.payment.amount.value", 10.5},
+		{"bool value", "order.paid", true},
+		{"array index", "order.amounts[0].currency", "USD"},
+		{"array second index", "order.amounts[1].currency", "GBP"},
+		{"array wildcard", "order.amounts.currency", "USD"},
+		{"array out of bounds", "order.amounts[5].currency", nil},
+		{"missing key", "order.missing.currency", nil},
+		{"path through scalar", "order.paid.currency", nil},
+		{"empty path", "", data},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(tt.expected, GetValueByJSONPath(data, tt.path))
+		})
+	}
+
+	t.Run("top-level array", func(t *testing.T) {
+		arr := decode(`[{"currency":"USD"},{"currency":"GBP"}]`)
+		assert.Equal("GBP", GetValueByJSONPath(arr, "[1].currency"))
+		assert.Equal("USD", GetValueByJSONPath(arr, "currency"))
+	})
+
+	t.Run("nil data", func(t *testing.T) {
+		assert.Nil(GetValueByJSONPath(nil, "order.currency"))
+	})
+}

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -1,24 +1,34 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 )
 
 // ContextHeaderName is the header name for passing context replacements via HTTP requests.
 // The value should be base64-encoded JSON.
 const ContextHeaderName = "X-Mockzilla-Context"
 
+// maxBufferedBodyBytes caps how much of a request body is kept for `request:`
+// context values. Paths into a payload larger than this aren't worth the memory.
+const maxBufferedBodyBytes = 1 << 20
+
 type contextKeyType struct{}
 
 type requestContextKeyType struct{}
 
+type requestBodyKeyType struct{}
+
 var (
 	userContextKey    = contextKeyType{}
 	requestContextKey = requestContextKeyType{}
+	requestBodyKey    = requestBodyKeyType{}
 )
 
 // ExtractContextFromRequest reads and decodes the X-Mockzilla-Context header from an HTTP request.
@@ -40,15 +50,24 @@ func ExtractContextFromRequest(r *http.Request) map[string]any {
 }
 
 // ContextReplacementsMiddleware extracts the X-Mockzilla-Context header and stores
-// the decoded context data on the request's Go context, along with the request itself.
+// the decoded context data on the request's Go context, along with the request itself
+// and a copy of its body.
 func ContextReplacementsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.WithValue(r.Context(), requestContextKey, r)
+		ctx := r.Context()
+		if body, ok := bufferRequestBody(r); ok {
+			ctx = context.WithValue(ctx, requestBodyKey, body)
+		}
 		if ctxData := ExtractContextFromRequest(r); ctxData != nil {
 			slog.Debug("User context from header", "data", ctxData)
 			ctx = context.WithValue(ctx, userContextKey, ctxData)
 		}
-		next.ServeHTTP(w, r.WithContext(ctx))
+
+		// The request stored under requestContextKey must carry the values
+		// above on its own context: handlers reach the buffered body through
+		// it, after the generated adapter has drained r.Body.
+		r = r.WithContext(ctx)
+		next.ServeHTTP(w, r.WithContext(context.WithValue(ctx, requestContextKey, r)))
 	})
 }
 
@@ -62,4 +81,48 @@ func UserContextFromGoContext(ctx context.Context) map[string]any {
 func RequestFromGoContext(ctx context.Context) *http.Request {
 	r, _ := ctx.Value(requestContextKey).(*http.Request)
 	return r
+}
+
+// RequestBodyFromGoContext retrieves the request body buffered by
+// ContextReplacementsMiddleware. Returns nil when nothing was buffered.
+func RequestBodyFromGoContext(ctx context.Context) []byte {
+	body, _ := ctx.Value(requestBodyKey).([]byte)
+	return body
+}
+
+// RequestBody returns the body of the incoming request, preferring the copy
+// buffered by ContextReplacementsMiddleware and falling back to reading r.Body
+// directly. The body is restored either way, so handlers can still read it.
+func RequestBody(r *http.Request) []byte {
+	if r == nil {
+		return nil
+	}
+	if body := RequestBodyFromGoContext(r.Context()); body != nil {
+		return body
+	}
+	body, _ := bufferRequestBody(r)
+	return body
+}
+
+// bufferRequestBody reads a structured request body into memory and restores
+// r.Body for the handlers downstream. Only payloads a context path can navigate
+// are buffered; uploads and unknown content types are left alone.
+func bufferRequestBody(r *http.Request) ([]byte, bool) {
+	if r.Body == nil || r.Body == http.NoBody || !isNavigableContentType(r.Header.Get("Content-Type")) {
+		return nil, false
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBufferedBodyBytes))
+	if err != nil {
+		return nil, false
+	}
+	r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), r.Body))
+
+	return body, len(body) > 0
+}
+
+func isNavigableContentType(contentType string) bool {
+	contentType = strings.ToLower(contentType)
+	return strings.Contains(contentType, "json") ||
+		strings.Contains(contentType, "application/x-www-form-urlencoded")
 }

--- a/pkg/api/context_test.go
+++ b/pkg/api/context_test.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 	"encoding/base64"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	assert2 "github.com/stretchr/testify/assert"
@@ -96,6 +98,71 @@ func TestContextReplacementsMiddleware(t *testing.T) {
 		stored := RequestFromGoContext(capturedCtx)
 		assert.NotNil(stored)
 		assert.Equal("/pets", stored.URL.Path)
+	})
+
+	t.Run("json body buffered and still readable by the handler", func(t *testing.T) {
+		const payload = `{"order":{"currency":"EUR"}}`
+
+		var handlerBody []byte
+		var capturedCtx context.Context
+		handler := ContextReplacementsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handlerBody, _ = io.ReadAll(r.Body)
+			capturedCtx = r.Context()
+		}))
+
+		r := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(payload))
+		r.Header.Set("Content-Type", "application/json")
+		handler.ServeHTTP(httptest.NewRecorder(), r)
+
+		assert.Equal(payload, string(handlerBody))
+
+		// the buffered copy outlives the handler draining the body
+		stored := RequestFromGoContext(capturedCtx)
+		assert.Equal(payload, string(RequestBody(stored)))
+	})
+
+	t.Run("upload body is not buffered", func(t *testing.T) {
+		var capturedCtx context.Context
+		handler := ContextReplacementsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+		}))
+
+		r := httptest.NewRequest(http.MethodPost, "/upload", strings.NewReader("binary"))
+		r.Header.Set("Content-Type", "application/octet-stream")
+		handler.ServeHTTP(httptest.NewRecorder(), r)
+
+		assert.Nil(RequestBodyFromGoContext(capturedCtx))
+	})
+}
+
+func TestRequestBody(t *testing.T) {
+	assert := assert2.New(t)
+
+	t.Run("nil request", func(t *testing.T) {
+		assert.Nil(RequestBody(nil))
+	})
+
+	t.Run("reads and restores the body", func(t *testing.T) {
+		const payload = `{"currency":"EUR"}`
+		r := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(payload))
+		r.Header.Set("Content-Type", "application/json")
+
+		assert.Equal(payload, string(RequestBody(r)))
+
+		rest, err := io.ReadAll(r.Body)
+		assert.NoError(err)
+		assert.Equal(payload, string(rest))
+	})
+
+	t.Run("body without a navigable content type", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPost, "/upload", strings.NewReader("binary"))
+		r.Header.Set("Content-Type", "application/octet-stream")
+		assert.Nil(RequestBody(r))
+	})
+
+	t.Run("no body", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/orders", nil)
+		assert.Nil(RequestBody(r))
 	})
 }
 

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -183,12 +183,13 @@ func (f *Factory) SuccessStatusCode(path, method string) int {
 // Response generates a mock response for the given spec path and method.
 // path should be the OpenAPI path pattern (e.g., "/users/{id}").
 // ctx is an optional replacement context for controlling generated values.
-func (f *Factory) Response(path, method string, ctx map[string]any) (schema.ResponseData, error) {
+// Pass generator.WithRequest to let `request:` context values read the incoming request.
+func (f *Factory) Response(path, method string, ctx map[string]any, opts ...generator.ResponseOption) (schema.ResponseData, error) {
 	respSchema := f.registry.GetResponseSchema(path, method)
 	if respSchema == nil {
 		return schema.ResponseData{}, fmt.Errorf("no operation found for %s %s", method, path)
 	}
-	return f.gen.Response(respSchema, ctx), nil
+	return f.gen.Response(respSchema, ctx, opts...), nil
 }
 
 // Request generates a mock request for the given spec path and method.
@@ -223,7 +224,7 @@ func (f *Factory) ResponseFromRequest(r *http.Request, ctx map[string]any) (sche
 	if !ok {
 		return schema.ResponseData{}, fmt.Errorf("no matching operation for %s %s", r.Method, r.URL.Path)
 	}
-	return f.Response(specPath, r.Method, ctx)
+	return f.Response(specPath, r.Method, ctx, generator.WithRequest(r))
 }
 
 // ResponseBody generates just the response body bytes for the given spec path and method.

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -14,7 +14,7 @@ import (
 
 type Generate interface {
 	Request(req *api.GenerateRequest, op *schema.Operation, ctxData map[string]any) json.RawMessage
-	Response(respSchema *schema.ResponseSchema, ctxData map[string]any) schema.ResponseData
+	Response(respSchema *schema.ResponseSchema, ctxData map[string]any, opts ...ResponseOption) schema.ResponseData
 	Error(errSchema *schema.Schema, errPath, error string) []byte
 }
 
@@ -22,10 +22,11 @@ type ResponseGenerator struct {
 	serviceContexts []map[string]any
 	defaultContexts []map[string]map[string]any
 	valueReplacer   replacer.ValueReplacer
+	usesRequestRefs bool
 }
 
 func (g *ResponseGenerator) Request(req *api.GenerateRequest, op *schema.Operation, ctxData map[string]any) json.RawMessage {
-	valueReplacer := g.resolveReplacer(ctxData)
+	valueReplacer, _ := g.resolveReplacer(ctxData)
 
 	// static resources.
 	if op == nil {
@@ -93,20 +94,32 @@ func (g *ResponseGenerator) Request(req *api.GenerateRequest, op *schema.Operati
 	return nil
 }
 
-func (g *ResponseGenerator) Response(respSchema *schema.ResponseSchema, ctxData map[string]any) schema.ResponseData {
+func (g *ResponseGenerator) Response(respSchema *schema.ResponseSchema, ctxData map[string]any, opts ...ResponseOption) schema.ResponseData {
 	// no response respSchema, nothing to generate
 	if respSchema == nil {
 		return schema.ResponseData{}
 	}
 
-	valueReplacer := g.resolveReplacer(ctxData)
+	valueReplacer, usesRequestRefs := g.resolveReplacer(ctxData)
 
-	state := replacer.NewReplaceState(
+	var requestOpts []replacer.ReplaceStateOption
+	if usesRequestRefs {
+		o := &responseOptions{}
+		for _, opt := range opts {
+			opt(o)
+		}
+		if payload := requestPayload(o.request); payload != nil {
+			requestOpts = append(requestOpts, replacer.WithRequestPayload(payload))
+		}
+	}
+
+	state := replacer.NewReplaceState(append([]replacer.ReplaceStateOption{
 		replacer.WithContentType(respSchema.ContentType),
-		replacer.WithReadOnly())
+		replacer.WithReadOnly(),
+	}, requestOpts...)...)
 
 	content := generateContentFromSchema(respSchema.Body, valueReplacer, state)
-	headers := generateHeaders(respSchema.Headers, valueReplacer)
+	headers := generateHeaders(respSchema.Headers, valueReplacer, requestOpts...)
 
 	isError := false
 	xmlRoot := ""
@@ -164,15 +177,19 @@ func (g *ResponseGenerator) Error(errSchema *schema.Schema, errPath, error strin
 }
 
 // resolveReplacer returns a valueReplacer with the given user context processed and prepended,
-// or the default valueReplacer if ctx is nil.
-func (g *ResponseGenerator) resolveReplacer(ctxData map[string]any) replacer.ValueReplacer {
+// or the default valueReplacer if ctx is nil. The second return value reports whether the
+// resulting contexts reference the request payload.
+func (g *ResponseGenerator) resolveReplacer(ctxData map[string]any) (replacer.ValueReplacer, bool) {
 	if len(ctxData) == 0 {
-		return g.valueReplacer
+		return g.valueReplacer, g.usesRequestRefs
 	}
 	yamlBytes, _ := yaml.Marshal(ctxData)
 	processed := contexts.Load(map[string][]byte{"user": yamlBytes}, g.defaultContexts)
-	orderedCtx := append([]map[string]any{processed["user"]}, g.serviceContexts...)
-	return replacer.CreateValueReplacer(replacer.Replacers, orderedCtx)
+	userCtx := processed["user"]
+	orderedCtx := append([]map[string]any{userCtx}, g.serviceContexts...)
+
+	usesRequestRefs := g.usesRequestRefs || contexts.HasRequestRefs([]map[string]any{userCtx})
+	return replacer.CreateValueReplacer(replacer.Replacers, orderedCtx), usesRequestRefs
 }
 
 func NewGenerator(orderedCtx []map[string]any, defaultContexts []map[string]map[string]any) (*ResponseGenerator, error) {
@@ -182,5 +199,6 @@ func NewGenerator(orderedCtx []map[string]any, defaultContexts []map[string]map[
 		serviceContexts: orderedCtx,
 		defaultContexts: defaultContexts,
 		valueReplacer:   valueReplacer,
+		usesRequestRefs: contexts.HasRequestRefs(orderedCtx),
 	}, nil
 }

--- a/pkg/generator/headers.go
+++ b/pkg/generator/headers.go
@@ -21,7 +21,7 @@ var skipHeaders = map[string]bool{
 // generateHeaders generates response headers from the given headers.
 // It filters out headers that would mislead HTTP clients about the response encoding
 // or content length, since these are managed by the HTTP transport layer.
-func generateHeaders(headers map[string]*schema.Schema, valueReplacer replacer.ValueReplacer) http.Header {
+func generateHeaders(headers map[string]*schema.Schema, valueReplacer replacer.ValueReplacer, opts ...replacer.ReplaceStateOption) http.Header {
 	res := http.Header{}
 
 	for name, s := range headers {
@@ -32,7 +32,9 @@ func generateHeaders(headers map[string]*schema.Schema, valueReplacer replacer.V
 			continue
 		}
 
-		state := replacer.NewReplaceState(replacer.WithName(name), replacer.WithHeader())
+		state := replacer.NewReplaceState(append([]replacer.ReplaceStateOption{
+			replacer.WithName(name), replacer.WithHeader(),
+		}, opts...)...)
 
 		value := generateContentFromSchema(s, valueReplacer, state)
 		res.Set(name, fmt.Sprintf("%v", value))

--- a/pkg/generator/request.go
+++ b/pkg/generator/request.go
@@ -1,0 +1,55 @@
+package generator
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
+	"github.com/mockzilla/mockzilla/v2/pkg/api"
+)
+
+// ResponseOption configures a single response generation.
+type ResponseOption func(*responseOptions)
+
+type responseOptions struct {
+	request *http.Request
+}
+
+// WithRequest exposes the incoming request to `request:` context values, whose
+// dotted paths are resolved against its payload.
+func WithRequest(r *http.Request) ResponseOption {
+	return func(o *responseOptions) {
+		o.request = r
+	}
+}
+
+// requestPayload decodes the request body into the structure `request:` context
+// paths navigate. The Content-Type header decides how the body is read: form
+// bodies go through the same runtime encoding mockzilla generates them with, so
+// deepObject keys (`order[payment][currency]`) and repeated keys land as nested
+// objects and arrays. Returns nil when there is nothing usable to navigate.
+func requestPayload(r *http.Request) any {
+	if r == nil {
+		return nil
+	}
+
+	body := api.RequestBody(r)
+	if len(body) == 0 {
+		return nil
+	}
+
+	if strings.Contains(strings.ToLower(r.Header.Get("Content-Type")), "application/x-www-form-urlencoded") {
+		converted, err := runtime.ConvertFormFields(body)
+		if err != nil {
+			return nil
+		}
+		body = converted
+	}
+
+	var payload any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil
+	}
+	return payload
+}

--- a/pkg/generator/request_test.go
+++ b/pkg/generator/request_test.go
@@ -1,0 +1,189 @@
+package generator
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mockzilla/mockzilla/v2/internal/types"
+	"github.com/mockzilla/mockzilla/v2/pkg/schema"
+	assert2 "github.com/stretchr/testify/assert"
+)
+
+const testRequestBody = `{
+	"order": {
+		"payment": {"amount": {"currency": "EUR", "value": 10.5}},
+		"amounts": [{"currency": "USD"}, {"currency": "GBP"}]
+	}
+}`
+
+func TestGenerator_ResponseWithRequest(t *testing.T) {
+	assert := assert2.New(t)
+	t.Parallel()
+
+	gen, err := NewGenerator(LoadServiceContext([]byte(`
+charge:
+  currency: "request:order.payment.amount.currency"
+  amount: "request:order.payment.amount.value"
+  first: "request:order.amounts[0].currency"
+  second: "request:order.amounts[1].currency"
+  missing: "request:order.payment.missing"
+`), nil), nil)
+	assert.NoError(err)
+
+	respSchema := &schema.ResponseSchema{
+		ContentType: "application/json",
+		Body: &schema.Schema{
+			Type: "object",
+			Properties: map[string]*schema.Schema{
+				"charge": {
+					Type: "object",
+					Properties: map[string]*schema.Schema{
+						"currency": {Type: "string"},
+						"amount":   {Type: "number"},
+						"first":    {Type: "string"},
+						"second":   {Type: "string"},
+						"missing":  {Type: "string", Enum: []any{"FALLBACK"}},
+					},
+				},
+			},
+		},
+	}
+
+	charge := func(res schema.ResponseData) map[string]any {
+		var body map[string]any
+		assert.NoError(json.Unmarshal(res.Body, &body))
+		return body["charge"].(map[string]any)
+	}
+
+	t.Run("values taken from the request payload", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(testRequestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		res := charge(gen.Response(respSchema, nil, WithRequest(req)))
+		assert.Equal("EUR", res["currency"])
+		assert.Equal(10.5, res["amount"])
+		assert.Equal("USD", res["first"])
+		assert.Equal("GBP", res["second"])
+		assert.Equal("FALLBACK", res["missing"])
+	})
+
+	t.Run("body stays readable for the caller", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(testRequestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		gen.Response(respSchema, nil, WithRequest(req))
+
+		body, err := io.ReadAll(req.Body)
+		assert.NoError(err)
+		assert.Equal(testRequestBody, string(body))
+	})
+
+	t.Run("response headers take values from the request payload", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(testRequestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		withHeaders := &schema.ResponseSchema{
+			ContentType: "application/json",
+			Body:        respSchema.Body,
+			Headers: map[string]*schema.Schema{
+				"X-Currency": {Type: "string"},
+			},
+		}
+
+		res := gen.Response(withHeaders, map[string]any{
+			"in-header": map[string]any{
+				"x-currency": "request:order.payment.amount.currency",
+			},
+		}, WithRequest(req))
+		assert.Equal("EUR", res.Headers.Get("x-currency"))
+	})
+
+	t.Run("without a request the schema value is generated", func(t *testing.T) {
+		res := charge(gen.Response(respSchema, nil))
+		assert.NotEqual("EUR", res["currency"])
+		assert.Equal("FALLBACK", res["missing"])
+	})
+
+	t.Run("user context can reference the request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(testRequestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		plain, err := NewGenerator(nil, nil)
+		assert.NoError(err)
+
+		res := charge(plain.Response(respSchema, map[string]any{
+			"currency": "request:order.amounts[1].currency",
+		}, WithRequest(req)))
+		assert.Equal("GBP", res["currency"])
+	})
+}
+
+func TestRequestPayload(t *testing.T) {
+	assert := assert2.New(t)
+	t.Parallel()
+
+	newRequest := func(contentType, body string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/orders", strings.NewReader(body))
+		req.Header.Set("Content-Type", contentType)
+		return req
+	}
+
+	t.Run("nil request", func(t *testing.T) {
+		assert.Nil(requestPayload(nil))
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		assert.Nil(requestPayload(newRequest("application/json", "")))
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		assert.Nil(requestPayload(newRequest("application/json", "not json")))
+	})
+
+	t.Run("unsupported content type", func(t *testing.T) {
+		assert.Nil(requestPayload(newRequest("application/octet-stream", testRequestBody)))
+	})
+
+	t.Run("json object", func(t *testing.T) {
+		payload, ok := requestPayload(newRequest("application/json", testRequestBody)).(map[string]any)
+		assert.True(ok)
+		assert.Contains(payload, "order")
+	})
+
+	t.Run("json array", func(t *testing.T) {
+		payload, ok := requestPayload(newRequest("application/json", `[{"currency":"USD"}]`)).([]any)
+		assert.True(ok)
+		assert.Len(payload, 1)
+	})
+
+	t.Run("form encoded", func(t *testing.T) {
+		payload, ok := requestPayload(newRequest(
+			"application/x-www-form-urlencoded; charset=utf-8",
+			"currency=USD&amount=10")).(map[string]any)
+		assert.True(ok)
+		assert.Equal("USD", payload["currency"])
+		assert.Equal(float64(10), payload["amount"])
+	})
+
+	t.Run("form encoded deep object", func(t *testing.T) {
+		payload := requestPayload(newRequest(
+			"application/x-www-form-urlencoded",
+			"order[payment][currency]=EUR&amounts[0][currency]=USD&amounts[1][currency]=GBP"))
+
+		assert.Equal("EUR", types.GetValueByJSONPath(payload, "order.payment.currency"))
+		assert.Equal("USD", types.GetValueByJSONPath(payload, "amounts[0].currency"))
+		assert.Equal("GBP", types.GetValueByJSONPath(payload, "amounts[1].currency"))
+	})
+
+	t.Run("form encoded repeated key", func(t *testing.T) {
+		payload := requestPayload(newRequest(
+			"application/x-www-form-urlencoded",
+			"currency=USD&currency=GBP"))
+
+		assert.Equal("GBP", types.GetValueByJSONPath(payload, "currency[1]"))
+	})
+}

--- a/pkg/middleware/jsonpath.go
+++ b/pkg/middleware/jsonpath.go
@@ -6,124 +6,19 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/mockzilla/mockzilla/v2/internal/types"
 )
 
-// pathSegment represents a single segment in a dotted path.
-type pathSegment struct {
-	key   string
-	index int  // -1 means no index
-	isArr bool // true if this segment has an array index like [0]
-}
-
 // extractJSONPath extracts a value from JSON bytes using a dotted path.
-// Supports:
-//   - Simple: "data.name" - traverse nested objects
-//   - Array index: "data.items[0].name" - specific element
-//   - Array wildcard: "data.items.name" - when items is an array, search each element
-//   - Top-level array: "[0].name" - index into a root-level array
+// See types.GetValueByJSONPath for the supported path syntax.
 func extractJSONPath(data []byte, path string) any {
 	var parsed any
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		return nil
 	}
 
-	segments := parseDottedPath(path)
-	return navigatePath(parsed, segments)
-}
-
-// parseDottedPath splits a dotted path into segments.
-// "data.items[0].name" → [{key:"data"}, {key:"items", index:0, isArr:true}, {key:"name"}]
-// "[0].name"           → [{key:"", index:0, isArr:true}, {key:"name"}]
-func parseDottedPath(path string) []pathSegment {
-	parts := strings.Split(path, ".")
-	segments := make([]pathSegment, 0, len(parts))
-
-	for _, part := range parts {
-		if part == "" {
-			continue
-		}
-
-		if idx := strings.Index(part, "["); idx != -1 {
-			key := part[:idx]
-			indexStr := strings.TrimSuffix(part[idx+1:], "]")
-			index, err := strconv.Atoi(indexStr)
-			if err != nil {
-				// Invalid index, treat as plain key
-				segments = append(segments, pathSegment{key: part, index: -1})
-				continue
-			}
-			segments = append(segments, pathSegment{key: key, index: index, isArr: true})
-		} else {
-			segments = append(segments, pathSegment{key: part, index: -1})
-		}
-	}
-
-	return segments
-}
-
-// navigatePath traverses the parsed JSON structure following the path segments.
-func navigatePath(current any, segments []pathSegment) any {
-	for i, seg := range segments {
-		if current == nil {
-			return nil
-		}
-
-		// Handle array at current level (top-level or bare index after traversal)
-		if arr, ok := current.([]any); ok {
-			if seg.isArr && seg.key == "" {
-				// Bare index like [0] - index directly into the current array
-				if seg.index < 0 || seg.index >= len(arr) {
-					return nil
-				}
-				current = arr[seg.index]
-				continue
-			}
-			// Array wildcard - search each element with remaining segments
-			remaining := segments[i:]
-			for _, elem := range arr {
-				result := navigatePath(elem, remaining)
-				if result != nil {
-					return result
-				}
-			}
-			return nil
-		}
-
-		switch v := current.(type) {
-		case map[string]any:
-			val, ok := v[seg.key]
-			if !ok {
-				return nil
-			}
-
-			if seg.isArr {
-				// Need to index into an array
-				arr, ok := val.([]any)
-				if !ok || seg.index < 0 || seg.index >= len(arr) {
-					return nil
-				}
-				current = arr[seg.index]
-			} else {
-				// Check if val is an array and we have more segments - wildcard search
-				if arr, ok := val.([]any); ok && i+1 < len(segments) {
-					remaining := segments[i+1:]
-					for _, elem := range arr {
-						result := navigatePath(elem, remaining)
-						if result != nil {
-							return result
-						}
-					}
-					return nil
-				}
-				current = val
-			}
-
-		default:
-			return nil
-		}
-	}
-
-	return current
+	return types.GetValueByJSONPath(parsed, path)
 }
 
 // extractBodyValue extracts a field value from the request body.

--- a/pkg/middleware/jsonpath_test.go
+++ b/pkg/middleware/jsonpath_test.go
@@ -121,48 +121,6 @@ func TestExtractJSONPath(t *testing.T) {
 	})
 }
 
-func TestParseDottedPath(t *testing.T) {
-	assert := assert2.New(t)
-
-	t.Run("simple path", func(t *testing.T) {
-		segments := parseDottedPath("data.name")
-		assert.Len(segments, 2)
-		assert.Equal("data", segments[0].key)
-		assert.Equal(-1, segments[0].index)
-		assert.Equal("name", segments[1].key)
-	})
-
-	t.Run("array index", func(t *testing.T) {
-		segments := parseDottedPath("data.items[0].name")
-		assert.Len(segments, 3)
-		assert.Equal("items", segments[1].key)
-		assert.Equal(0, segments[1].index)
-		assert.True(segments[1].isArr)
-	})
-
-	t.Run("invalid array index treated as key", func(t *testing.T) {
-		segments := parseDottedPath("data.items[abc].name")
-		assert.Len(segments, 3)
-		assert.Equal("items[abc]", segments[1].key)
-		assert.Equal(-1, segments[1].index)
-		assert.False(segments[1].isArr)
-	})
-
-	t.Run("bare array index", func(t *testing.T) {
-		segments := parseDottedPath("[0].name")
-		assert.Len(segments, 2)
-		assert.Equal("", segments[0].key)
-		assert.Equal(0, segments[0].index)
-		assert.True(segments[0].isArr)
-		assert.Equal("name", segments[1].key)
-	})
-
-	t.Run("empty path", func(t *testing.T) {
-		segments := parseDottedPath("")
-		assert.Empty(segments)
-	})
-}
-
 func TestExtractBodyValue(t *testing.T) {
 	assert := assert2.New(t)
 


### PR DESCRIPTION
## Take response values from the incoming request

Context files can now pull a value straight out of the request being answered,
with a dotted path into its payload:

```yaml
charge:
  currency: "request:order.payment.amount.currency"
  amount: "request:order.payment.amount.value"
```

Post an order with `EUR` and `10.5`, and the mock answers with `EUR` and `10.5`
instead of random data. Array elements are addressed by index:
`request:order.amounts[0].currency`.

## Why it matters

- **Mocks that behave like the real API.** Create-then-read flows finally line
  up: what a client sends is what it gets back, so demos and screen recordings
  stop showing nonsense values next to the data the user just typed.
- **Front-end work without a backend.** Forms, carts and checkout screens can be
  built end to end against a mock, because the response reflects the input.
- **Contract tests that assert on echoed fields.** Test suites checking that an
  id, currency or reference survives the round trip now pass against mockzilla,
  which previously forced those assertions to be skipped or stubbed by hand.
- **No per-endpoint setup.** It is one line in the context file, next to the
  existing `fake:` and `func:` values, and it works for every endpoint that
  receives that field.
- **Safe by default.** A path that does not match anything (missing field, no
  body, wrong shape) quietly falls back to generated data, so nothing breaks
  when a request does not carry the field.

## Availability

Works in every mode: portable, generated services, and the programmatic API.
Values can come from JSON or form-encoded requests, and can be set per request
through the context header and the UI context editor.
