### PR TITLE
Fix response header generation

### DIFF
--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -376,16 +376,19 @@ in-response-header:
 **Priority chain (most specific wins):**
 
 ```
-in-request-header > in-header > in-request > root
-in-response-header > in-header > in-response > root
+in-request-header > in-request > in-header > root
+in-response-header > in-response > in-header > root
 ```
+
+Direction wins over `in-header`: a header falls back to `in-request` / `in-response`
+before the direction-agnostic `in-header`.
 
 Available compound areas:
 
 | Area | Applies to |
 |------|-----------|
-| `in-request` | Request body and query parameters |
-| `in-response` | Response body |
+| `in-request` | Request body, query parameters, and request headers not covered by `in-request-header` |
+| `in-response` | Response body, and response headers not covered by `in-response-header` |
 | `in-request-header` | Request headers only |
 | `in-response-header` | Response headers only |
 

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -75,6 +75,42 @@ func TestGenerator_Generate(t *testing.T) {
 		assert.False(res.IsError)
 	})
 
+	t.Run("response header area priority", func(t *testing.T) {
+		// in-response-header > in-response > in-header > root
+		areaGen, err := NewGenerator(LoadServiceContext([]byte(`
+x-one: "root"
+x-two: "root"
+x-three: "root"
+x-four: "root"
+in-header:
+  x-one: "header"
+  x-two: "header"
+  x-three: "header"
+in-response:
+  x-one: "response"
+  x-two: "response"
+in-response-header:
+  x-one: "response-header"
+`), nil), nil)
+		assert.NoError(err)
+
+		res := areaGen.Response(&schema.ResponseSchema{
+			ContentType: "application/json",
+			Body:        &schema.Schema{Type: "object", Properties: map[string]*schema.Schema{}, Nullable: true},
+			Headers: map[string]*schema.Schema{
+				"X-One":   {Type: "string"},
+				"X-Two":   {Type: "string"},
+				"X-Three": {Type: "string"},
+				"X-Four":  {Type: "string"},
+			},
+		}, nil)
+
+		assert.Equal("response-header", res.Headers.Get("x-one"))
+		assert.Equal("response", res.Headers.Get("x-two"))
+		assert.Equal("header", res.Headers.Get("x-three"))
+		assert.Equal("root", res.Headers.Get("x-four"))
+	})
+
 	t.Run("xml response uses schema name as root element", func(t *testing.T) {
 		respSchema := &schema.ResponseSchema{
 			ContentType: "application/xml",

--- a/pkg/generator/headers.go
+++ b/pkg/generator/headers.go
@@ -32,11 +32,17 @@ func generateHeaders(headers map[string]*schema.Schema, valueReplacer replacer.V
 			continue
 		}
 
+		// Response headers are read-only content: without the flag the
+		// `in-response-header` area never matches and `readOnly` header
+		// schemas - the ones that belong in a response - get filtered out.
 		state := replacer.NewReplaceState(append([]replacer.ReplaceStateOption{
-			replacer.WithName(name), replacer.WithHeader(),
+			replacer.WithName(name), replacer.WithHeader(), replacer.WithReadOnly(),
 		}, opts...)...)
 
 		value := generateContentFromSchema(s, valueReplacer, state)
+		if value == nil {
+			continue
+		}
 		res.Set(name, fmt.Sprintf("%v", value))
 	}
 	return res

--- a/pkg/generator/headers_test.go
+++ b/pkg/generator/headers_test.go
@@ -37,6 +37,24 @@ func TestGenerateHeaders(t *testing.T) {
 		assert.Equal(expected, res)
 	})
 
+	t.Run("keeps readOnly headers and drops writeOnly ones", func(t *testing.T) {
+		valueReplacer := func(schema any, state *replacer.ReplaceState) any {
+			return "value"
+		}
+
+		headers := map[string]*schema.Schema{
+			"X-Read-Only":  {Type: "string", ReadOnly: true},
+			"X-Write-Only": {Type: "string", WriteOnly: true},
+			"X-Plain":      {Type: "string"},
+		}
+
+		res := generateHeaders(headers, valueReplacer)
+
+		assert.Equal("value", res.Get("X-Read-Only"))
+		assert.Equal("value", res.Get("X-Plain"))
+		assert.NotContains(res, "X-Write-Only")
+	})
+
 	t.Run("filters out transport-managed headers", func(t *testing.T) {
 		valueReplacer := func(schema any, state *replacer.ReplaceState) any {
 			switch state.NamePath[len(state.NamePath)-1] {


### PR DESCRIPTION
An `in-response-header` block was ignored, so headers meant to carry a fixed
request id, rate limit or trace id came back as random words. There was no error
and no warning; the only signal was a wrong value in the response.

Two related problems came from the same cause. Headers marked `readOnly` in the
spec - exactly the ones that belong in a response - were dropped and sent as the
literal text `<nil>`. Headers marked `writeOnly` were sent as `<nil>` too,
instead of being left out. Clients reading those headers received a string that
looks like a value but is not, which is worse than an absent header: assertions
pass on the wrong thing and parsers fail far from the cause.

## What changed

- `in-response-header` and `in-response` now apply to response headers, so
  header values can be pinned the same way body values already could.
- Headers declared `readOnly` appear in responses with their generated value.
- Headers that do not belong in a response are omitted rather than sent as
  `<nil>`.

## Impact

- Fixed, predictable response headers for contract tests and recorded fixtures.
- No more `<nil>` header values reaching clients.
- No configuration changes; existing contexts keep working, and contexts that
  already contained an `in-response-header` block start taking effect.
