### PR TITLE
Share OpenAPI overlays between services

### DIFF
--- a/cmd/api/service.go
+++ b/cmd/api/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/codegen"
 	"github.com/mockzilla/mockzilla/v2/cmd/gen/templatehelpers"
 	"github.com/mockzilla/mockzilla/v2/internal/files"
+	"github.com/mockzilla/mockzilla/v2/internal/overlay"
 	"github.com/mockzilla/mockzilla/v2/internal/types"
 	"github.com/mockzilla/mockzilla/v2/pkg/config"
 	"github.com/mockzilla/mockzilla/v2/pkg/typedef"
@@ -192,20 +193,21 @@ func GenerateService(opts ServiceOptions) error {
 	}
 	cfg = cfg.WithDefaults()
 
-	// Resolve overlay paths to be absolute (relative to setup directory)
+	// Read overlays once: their contents go into the generated service, their
+	// resolved paths into the config oapi-codegen generates from.
 	if cfg.Overlay != nil && len(cfg.Overlay.Sources) > 0 {
-		// Save original filenames for go:embed directives in generated code
+		overlays, err := overlay.Resolve(setupDir, cfg.Overlay.Sources)
+		if err != nil {
+			return err
+		}
+
 		if cfg.UserContext == nil {
 			cfg.UserContext = make(map[string]any)
 		}
-		overlayFiles := make([]string, len(cfg.Overlay.Sources))
-		copy(overlayFiles, cfg.Overlay.Sources)
-		cfg.UserContext["OverlayFiles"] = overlayFiles
+		cfg.UserContext["Overlays"] = overlays
 
-		for i, src := range cfg.Overlay.Sources {
-			if !filepath.IsAbs(src) && !files.IsURL(src) {
-				cfg.Overlay.Sources[i] = filepath.Join(setupDir, src)
-			}
+		for i := range cfg.Overlay.Sources {
+			cfg.Overlay.Sources[i] = overlays[i].Path
 		}
 	}
 
@@ -295,8 +297,6 @@ func GenerateService(opts ServiceOptions) error {
 	// Imports only the overlay-application code path needs at runtime.
 	if cfg.Overlay != nil && len(cfg.Overlay.Sources) > 0 {
 		cfg.AdditionalImports = append(cfg.AdditionalImports,
-			codegen.AdditionalImport{Alias: "oapicodegen", Package: "github.com/doordash-oss/oapi-codegen-dd/v3/pkg/codegen"},
-			codegen.AdditionalImport{Alias: "yamlv4", Package: "go.yaml.in/yaml/v4"},
 			codegen.AdditionalImport{Package: "github.com/pb33f/libopenapi"},
 		)
 	}

--- a/cmd/api/templates/handler/chi/handler.tmpl
+++ b/cmd/api/templates/handler/chi/handler.tmpl
@@ -83,13 +83,22 @@ var openapiSpecFS embed.FS
 
 //go:embed setup/context.yml
 var contextSrc []byte
-{{- if $config.UserContext }}{{- with index $config.UserContext "OverlayFiles" }}
+{{- if $config.UserContext }}{{- with index $config.UserContext "Overlays" }}
 
-//go:embed setup/codegen.yml
-var codegenConfigSrc []byte
-
-//go:embed{{ range . }} setup/{{ . }}{{ end }}
-var overlayFS embed.FS
+// overlays holds the OpenAPI Overlay documents configured for this service,
+// inlined at generation time so runtime applies the same bytes the generated
+// types were built from. Applied in configured order.
+var overlays = []struct {
+	Name    string
+	Content string
+}{
+{{- range . }}
+	{
+		Name: {{ printf "%q" .Name }},
+		Content: {{ .Literal }},
+	},
+{{- end }}
+}
 {{- end }}{{- end }}
 
 var cfg *config.ServiceConfig
@@ -117,26 +126,15 @@ func RegisterAPIRouter(router *api.Router) {
 		)
 		return
 	}
-{{- if $config.UserContext }}{{- with index $config.UserContext "OverlayFiles" }}
+{{- if $config.UserContext }}{{- with index $config.UserContext "Overlays" }}
 
-	var codegenCfg oapicodegen.Configuration
-	if err := yamlv4.Unmarshal(codegenConfigSrc, &codegenCfg); err != nil {
-		slog.Error(fmt.Sprintf("Failed to parse codegen config for %s", serviceName),
+	openapiSpec, err = applyOverlays(openapiSpec)
+	if err != nil {
+		slog.Error(fmt.Sprintf("Failed to apply overlay for %s", serviceName),
 			"error", err,
 			"service", serviceName,
 		)
 		return
-	}
-
-	if codegenCfg.Overlay != nil && len(codegenCfg.Overlay.Sources) > 0 {
-		openapiSpec, err = applyEmbeddedOverlays(openapiSpec, overlayFS, codegenCfg.Overlay.Sources)
-		if err != nil {
-			slog.Error(fmt.Sprintf("Failed to apply overlay for %s", serviceName),
-				"error", err,
-				"service", serviceName,
-			)
-			return
-		}
 	}
 {{- end }}{{- end }}
 
@@ -191,19 +189,14 @@ func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
 	}
 	return nil, errors.New("no file found in embedded filesystem")
 }
-{{- if $config.UserContext }}{{- with index $config.UserContext "OverlayFiles" }}
+{{- if $config.UserContext }}{{- with index $config.UserContext "Overlays" }}
 
-// applyEmbeddedOverlays applies overlay files to the OpenAPI spec bytes.
-// Sources are read from the embedded filesystem in the order specified.
-func applyEmbeddedOverlays(spec []byte, fsys embed.FS, sources []string) ([]byte, error) {
-	for _, src := range sources {
-		overlay, err := fsys.ReadFile(path.Join("setup", src))
+// applyOverlays applies the inlined overlay documents to the OpenAPI spec bytes.
+func applyOverlays(spec []byte) ([]byte, error) {
+	for _, overlay := range overlays {
+		result, err := libopenapi.ApplyOverlayFromBytesToSpecBytes(spec, []byte(overlay.Content))
 		if err != nil {
-			return nil, fmt.Errorf("reading overlay %s: %w", src, err)
-		}
-		result, err := libopenapi.ApplyOverlayFromBytesToSpecBytes(spec, overlay)
-		if err != nil {
-			return nil, fmt.Errorf("applying overlay %s: %w", src, err)
+			return nil, fmt.Errorf("applying overlay %s: %w", overlay.Name, err)
 		}
 		spec = result.Bytes
 	}
@@ -368,18 +361,11 @@ func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
 	if err != nil {
 		return nil, err
 	}
-{{- if $config.UserContext }}{{- with index $config.UserContext "OverlayFiles" }}
+{{- if $config.UserContext }}{{- with index $config.UserContext "Overlays" }}
 
-	var codegenCfg oapicodegen.Configuration
-	if err := yamlv4.Unmarshal(codegenConfigSrc, &codegenCfg); err != nil {
-		return nil, err
-	}
-
-	if codegenCfg.Overlay != nil && len(codegenCfg.Overlay.Sources) > 0 {
-		openapiSpec, err = applyEmbeddedOverlays(openapiSpec, overlayFS, codegenCfg.Overlay.Sources)
-		if err != nil {
-			return nil, fmt.Errorf("applying overlay: %w", err)
-		}
+	openapiSpec, err = applyOverlays(openapiSpec)
+	if err != nil {
+		return nil, fmt.Errorf("applying overlay: %w", err)
 	}
 {{- end }}{{- end }}
 

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -1,0 +1,56 @@
+package overlay
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/mockzilla/mockzilla/v2/internal/files"
+)
+
+// Source is one resolved OpenAPI Overlay: Name as configured (used in error
+// messages), Path for generation, and Literal for the generated service.
+type Source struct {
+	Name    string
+	Path    string
+	Literal string
+}
+
+// Resolve reads every configured overlay, resolving relative paths against
+// setupDir. Contents are inlined into the generated service rather than
+// embedded: go:embed cannot reach outside the package directory, so overlays
+// shared between API versions (../) and URL sources have no embeddable path.
+func Resolve(setupDir string, sources []string) ([]Source, error) {
+	overlays := make([]Source, 0, len(sources))
+	for _, src := range sources {
+		path := src
+		if !filepath.IsAbs(path) && !files.IsURL(path) {
+			path = filepath.Join(setupDir, path)
+		}
+
+		contents, err := files.ReadFileOrURL(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading overlay %q: %w", src, err)
+		}
+
+		resolved := Source{
+			Name:    src,
+			Path:    path,
+			Literal: goStringLiteral(string(contents)),
+		}
+		overlays = append(overlays, resolved)
+	}
+
+	return overlays, nil
+}
+
+// goStringLiteral renders s as Go source, preferring a raw string so the
+// overlay stays readable in the generated file. Raw strings cannot hold
+// backquotes or carriage returns, so those fall back to a quoted string.
+func goStringLiteral(s string) string {
+	if strings.ContainsAny(s, "`\r") {
+		return strconv.Quote(s)
+	}
+	return "`" + s + "`"
+}

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -1,0 +1,116 @@
+package overlay
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	root := t.TempDir()
+	setupDir := filepath.Join(root, "v71", "setup")
+	sharedDir := filepath.Join(root, "setup")
+	for _, dir := range []string{setupDir, sharedDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	local := filepath.Join(setupDir, "overlay.yml")
+	if err := os.WriteFile(local, []byte("local: yes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(sharedDir, "overlay.yml")
+	if err := os.WriteFile(shared, []byte("shared: yes\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("remote: yes\n"))
+	}))
+	defer srv.Close()
+
+	remote := srv.URL + "/overlay.yml"
+
+	tests := []struct {
+		name    string
+		sources []string
+		want    []Source
+	}{
+		{
+			name:    "relative to setup dir",
+			sources: []string{"overlay.yml"},
+			want: []Source{
+				{Name: "overlay.yml", Path: local, Literal: "`local: yes\n`"},
+			},
+		},
+		{
+			name:    "shared overlay above the setup dir",
+			sources: []string{"../../setup/overlay.yml", "overlay.yml"},
+			want: []Source{
+				{Name: "../../setup/overlay.yml", Path: shared, Literal: "`shared: yes\n`"},
+				{Name: "overlay.yml", Path: local, Literal: "`local: yes\n`"},
+			},
+		},
+		{
+			name:    "absolute path",
+			sources: []string{shared},
+			want: []Source{
+				{Name: shared, Path: shared, Literal: "`shared: yes\n`"},
+			},
+		},
+		{
+			name:    "url",
+			sources: []string{remote},
+			want: []Source{
+				{Name: remote, Path: remote, Literal: "`remote: yes\n`"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Resolve(setupDir, tt.sources)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Resolve() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveMissingSource(t *testing.T) {
+	_, err := Resolve(t.TempDir(), []string{"absent.yml"})
+	if err == nil {
+		t.Fatal("expected an error for a missing overlay")
+	}
+	if got := err.Error(); !strings.Contains(got, "absent.yml") {
+		t.Errorf("error %q does not name the configured source", got)
+	}
+}
+
+func TestGoStringLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "raw string", in: "overlay: 1.0.0\n", want: "`overlay: 1.0.0\n`"},
+		{name: "backquote falls back to quoted", in: "a: `b`", want: `"a: ` + "`b`" + `"`},
+		{name: "carriage return falls back to quoted", in: "a: b\r\n", want: `"a: b\r\n"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := goStringLiteral(tt.in); got != tt.want {
+				t.Errorf("goStringLiteral(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Overlay sources are no longer restricted to a service's own setup directory. A service can now apply an overlay kept in a shared location, referenced by an absolute path, or published at a URL. Multiple sources apply in order, so a later one refines what an earlier one set.