### PR TITLE
Add service failures in its own error shape

### DIFF
--- a/cmd/api/templates/handler/chi/handler.tmpl
+++ b/cmd/api/templates/handler/chi/handler.tmpl
@@ -24,6 +24,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
         cfg.errHandler = h
     }
 }
+
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
 {{end}}
 
 {{define "new-router"}}
@@ -219,7 +226,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc {{ $modelsPrefix }}ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   {{ $modelsPrefix }}NewRouter(svc),
+		router:   {{ $modelsPrefix }}NewRouter(svc, {{ $modelsPrefix }}WithErrorHandler({{ $modelsPrefix }}ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,

--- a/examples/commands/service/petstore/gen.go
+++ b/examples/commands/service/petstore/gen.go
@@ -1649,6 +1649,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
 	}
 }
 
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
+
 // NewRouter creates a new chi.Router with the given service implementation.
 func NewRouter(svc ServiceInterface, opts ...RouterOption) chi.Router {
 	cfg := &routerConfig{}
@@ -1791,7 +1798,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   NewRouter(svc),
+		router:   NewRouter(svc, WithErrorHandler(ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,

--- a/examples/commands/service/static/gen.go
+++ b/examples/commands/service/static/gen.go
@@ -207,6 +207,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
 	}
 }
 
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
+
 // NewRouter creates a new chi.Router with the given service implementation.
 func NewRouter(svc ServiceInterface, opts ...RouterOption) chi.Router {
 	cfg := &routerConfig{}
@@ -331,7 +338,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   NewRouter(svc),
+		router:   NewRouter(svc, WithErrorHandler(ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,

--- a/examples/commands/service/users/gen.go
+++ b/examples/commands/service/users/gen.go
@@ -654,6 +654,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
 	}
 }
 
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
+
 // NewRouter creates a new chi.Router with the given service implementation.
 func NewRouter(svc ServiceInterface, opts ...RouterOption) chi.Router {
 	cfg := &routerConfig{}
@@ -788,7 +795,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   NewRouter(svc),
+		router:   NewRouter(svc, WithErrorHandler(ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,

--- a/examples/commands/service/zero-endpoints/gen.go
+++ b/examples/commands/service/zero-endpoints/gen.go
@@ -143,6 +143,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
 	}
 }
 
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
+
 // NewRouter creates a new chi.Router with the given service implementation.
 func NewRouter(svc ServiceInterface, opts ...RouterOption) chi.Router {
 	cfg := &routerConfig{}
@@ -265,7 +272,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   NewRouter(svc),
+		router:   NewRouter(svc, WithErrorHandler(ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,

--- a/examples/docker-compose/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/petstore/gen.go
@@ -1230,6 +1230,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
 	}
 }
 
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
+
 // NewRouter creates a new chi.Router with the given service implementation.
 func NewRouter(svc ServiceInterface, opts ...RouterOption) chi.Router {
 	cfg := &routerConfig{}
@@ -1372,7 +1379,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   NewRouter(svc),
+		router:   NewRouter(svc, WithErrorHandler(ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,

--- a/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
@@ -10744,6 +10744,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
 	}
 }
 
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
+
 // NewRouter creates a new chi.Router with the given service implementation.
 func NewRouter(svc ServiceInterface, opts ...RouterOption) chi.Router {
 	cfg := &routerConfig{}
@@ -10966,7 +10973,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   NewRouter(svc),
+		router:   NewRouter(svc, WithErrorHandler(ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,

--- a/examples/docker/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker/pre-generated-services/services/petstore/gen.go
@@ -1230,6 +1230,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
 	}
 }
 
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
+
 // NewRouter creates a new chi.Router with the given service implementation.
 func NewRouter(svc ServiceInterface, opts ...RouterOption) chi.Router {
 	cfg := &routerConfig{}
@@ -1372,7 +1379,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   NewRouter(svc),
+		router:   NewRouter(svc, WithErrorHandler(ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,

--- a/examples/docker/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker/pre-generated-services/services/spoonacular/gen.go
@@ -10744,6 +10744,13 @@ func WithErrorHandler(h OapiErrorHandler) RouterOption {
 	}
 }
 
+// ServiceErrorHandler answers the failures raised before the service is reached:
+// parameter parsing, body decoding and request validation. Those never return
+// through the service, so no spec-declared error type describes them and
+// error-mapping does not reach them. A service whose API has an error shape of
+// its own replaces this at init.
+var ServiceErrorHandler OapiErrorHandler = &OapiDefaultErrorHandler{}
+
 // NewRouter creates a new chi.Router with the given service implementation.
 func NewRouter(svc ServiceInterface, opts ...RouterOption) chi.Router {
 	cfg := &routerConfig{}
@@ -10966,7 +10973,7 @@ type serviceHandler struct {
 // newServiceHandler creates a new serviceHandler.
 func newServiceHandler(svc ServiceInterface, gen generator.Generate, registry typedef.OperationRegistry) api.Handler {
 	return &serviceHandler{
-		router:   NewRouter(svc),
+		router:   NewRouter(svc, WithErrorHandler(ServiceErrorHandler)),
 		service:  svc,
 		gen:      gen,
 		registry: registry,


### PR DESCRIPTION
A generated service can now replace the handler for the failures raised before its code is reached - parameter parsing, body decoding and request validation - by assigning to `ServiceErrorHandler` at init. 
