### PR TITLE
Resolve a $ref that carries sibling keys to the schema it names

### DIFF
--- a/pkg/typedef/internal/libopenapi/registry.go
+++ b/pkg/typedef/internal/libopenapi/registry.go
@@ -16,7 +16,9 @@ import (
 	"github.com/mockzilla/mockzilla/v2/pkg/schema"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
 )
 
 // Options configures the libopenapi-direct provider.
@@ -132,6 +134,15 @@ func (r *Registry) Document() (libopenapi.Document, error) {
 	return r.doc, nil
 }
 
+// componentSchemas is the document's schema components, or nil when it declares
+// none. convertCtx resolves a $ref against them.
+func (r *Registry) componentSchemas() *orderedmap.Map[string, *base.SchemaProxy] {
+	if r.model == nil || r.model.Components == nil {
+		return nil
+	}
+	return r.model.Components.Schemas
+}
+
 func (r *Registry) buildIndex() {
 	if r.model == nil || r.model.Paths == nil || r.model.Paths.PathItems == nil {
 		return
@@ -182,6 +193,7 @@ func (r *Registry) convertOperation(e *opEntry) *schema.Operation {
 	}
 
 	ctx := newConvertCtx()
+	ctx.components = r.componentSchemas()
 	id := operationID(op, e.method, e.path)
 	id = r.uniqueOperationID(id)
 

--- a/pkg/typedef/internal/libopenapi/registry_test.go
+++ b/pkg/typedef/internal/libopenapi/registry_test.go
@@ -223,3 +223,34 @@ paths:
 	require.NotNil(t, op.Response.GetSuccess())
 	assert.Equal(t, "text/plain", op.Response.GetSuccess().ContentType)
 }
+
+// componentSchemas backs $ref resolution in convertProxy; specWithRefSiblings
+// (schema_test.go) is the fixture it shares with those cases.
+func TestComponentSchemas(t *testing.T) {
+	t.Run("returns the document's schemas", func(t *testing.T) {
+		reg, err := NewRegistry([]byte(specWithRefSiblings), Options{})
+		require.NoError(t, err)
+
+		components := reg.componentSchemas()
+		require.NotNil(t, components)
+		assert.Equal(t, 3, components.Len())
+
+		for _, name := range []string{"Amount", "Total", "Wrapper"} {
+			_, ok := components.Get(name)
+			assert.True(t, ok, name)
+		}
+	})
+
+	t.Run("nil when the document declares none", func(t *testing.T) {
+		spec := `openapi: 3.1.0
+info: {title: t, version: 1}
+paths: {}`
+		reg, err := NewRegistry([]byte(spec), Options{})
+		require.NoError(t, err)
+		assert.Nil(t, reg.componentSchemas())
+	})
+
+	t.Run("nil without a model", func(t *testing.T) {
+		assert.Nil(t, (&Registry{}).componentSchemas())
+	})
+}

--- a/pkg/typedef/internal/libopenapi/schema.go
+++ b/pkg/typedef/internal/libopenapi/schema.go
@@ -30,6 +30,11 @@ type convertCtx struct {
 	cache    map[string]*schema.Schema
 	depth    map[string]int
 	maxDepth int
+
+	// components resolves a $ref back to the schema it names. A $ref carrying
+	// sibling keys resolves to those siblings alone, not to its target, so the
+	// target has to be looked up by name; see resolveTarget.
+	components *orderedmap.Map[string, *base.SchemaProxy]
 }
 
 func newConvertCtx() *convertCtx {
@@ -38,6 +43,34 @@ func newConvertCtx() *convertCtx {
 		depth:    map[string]int{},
 		maxDepth: defaultMaxRecursionDepth,
 	}
+}
+
+// componentRefPrefix is the only $ref shape this resolves; anything else (a
+// remote or path reference) is left to the proxy's own schema.
+const componentRefPrefix = "#/components/schemas/"
+
+// resolveTarget returns the schema a $ref names, or nil when the reference is
+// not a component this document holds.
+//
+// In OpenAPI 3.1 a $ref may carry sibling keys, which are annotations - the
+// reference still decides the shape. libopenapi hands back only the siblings
+// from such a node, so converting it directly yields a schema with no type and
+// no properties, which then renders as a bare string.
+func (c *convertCtx) resolveTarget(proxy *base.SchemaProxy) *base.Schema {
+	if c == nil || c.components == nil || proxy == nil || !proxy.IsReference() {
+		return nil
+	}
+
+	name, ok := strings.CutPrefix(proxy.GetReference(), componentRefPrefix)
+	if !ok {
+		return nil
+	}
+
+	target, ok := c.components.Get(name)
+	if !ok || target == nil {
+		return nil
+	}
+	return target.Schema()
 }
 
 // schemaIdentity returns a stable cache/depth key for a SchemaProxy +
@@ -65,6 +98,9 @@ func convertProxy(proxy *base.SchemaProxy, ctx *convertCtx) *schema.Schema {
 		return nil
 	}
 	s := proxy.Schema()
+	if target := ctx.resolveTarget(proxy); target != nil {
+		s = target
+	}
 	if s == nil {
 		return nil
 	}

--- a/pkg/typedef/internal/libopenapi/schema_test.go
+++ b/pkg/typedef/internal/libopenapi/schema_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mockzilla/mockzilla/v2/internal/types"
 	"github.com/mockzilla/mockzilla/v2/pkg/schema"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -573,4 +574,118 @@ func TestShortName(t *testing.T) {
 	assert.Equal(t, "Foo", shortName("#/components/schemas/Foo"))
 	assert.Equal(t, "bare", shortName("bare"))
 	assert.Equal(t, "", shortName(""))
+}
+
+// specWithRefSiblings declares one property as a bare $ref and one as a $ref
+// carrying sibling keys, which OpenAPI 3.1 permits as annotations.
+const specWithRefSiblings = `openapi: 3.1.0
+info: {title: t, version: 1}
+paths:
+  /thing:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Wrapper'
+components:
+  schemas:
+    Amount:
+      type: object
+      properties:
+        currency: {type: string}
+        value: {type: integer}
+      required: [currency, value]
+    Total:
+      type: object
+      properties:
+        currency: {type: string}
+        value: {type: integer}
+      required: [currency, value]
+    Wrapper:
+      type: object
+      properties:
+        bare:
+          $ref: '#/components/schemas/Amount'
+        annotated:
+          $ref: '#/components/schemas/Total'
+          description: carries a sibling key
+`
+
+// A $ref with sibling keys resolves to the schema it names, not to the siblings.
+// libopenapi hands back only the sibling node, which would otherwise convert to
+// a typeless schema and render as a bare string.
+func TestConvertProxy_RefWithSiblingsResolvesTarget(t *testing.T) {
+	reg, err := NewRegistry([]byte(specWithRefSiblings), Options{})
+	require.NoError(t, err)
+
+	op := reg.FindOperation("/thing", "GET")
+	require.NotNil(t, op)
+	content := op.Response.GetSuccess().Content
+	require.NotNil(t, content)
+
+	// Each property names a different target: a bare ref converted first would
+	// otherwise populate the cache under that ref and hide the annotated one.
+	for name, want := range map[string]string{"bare": "Amount", "annotated": "Total"} {
+		t.Run(name, func(t *testing.T) {
+			prop, ok := content.Properties[name]
+			require.True(t, ok)
+			assert.Equal(t, "object", prop.Type)
+			assert.Len(t, prop.Properties, 2)
+			assert.Equal(t, want, prop.Name)
+			assert.ElementsMatch(t, []string{"currency", "value"}, prop.Required)
+		})
+	}
+}
+
+func TestResolveTarget(t *testing.T) {
+	reg, err := NewRegistry([]byte(specWithRefSiblings), Options{})
+	require.NoError(t, err)
+
+	components := reg.componentSchemas()
+	require.NotNil(t, components)
+
+	wrapper, ok := components.Get("Wrapper")
+	require.True(t, ok)
+	annotated, ok := wrapper.Schema().Properties.Get("annotated")
+	require.True(t, ok)
+
+	t.Run("resolves a component reference", func(t *testing.T) {
+		ctx := newConvertCtx()
+		ctx.components = components
+
+		target := ctx.resolveTarget(annotated)
+		require.NotNil(t, target)
+		assert.Equal(t, 2, target.Properties.Len())
+	})
+
+	t.Run("nil without components to resolve against", func(t *testing.T) {
+		assert.Nil(t, newConvertCtx().resolveTarget(annotated))
+	})
+
+	t.Run("nil for an inline schema", func(t *testing.T) {
+		ctx := newConvertCtx()
+		ctx.components = components
+
+		amount, ok := components.Get("Amount")
+		require.True(t, ok)
+		inline, ok := amount.Schema().Properties.Get("currency")
+		require.True(t, ok)
+		assert.Nil(t, ctx.resolveTarget(inline))
+	})
+
+	t.Run("nil for a reference this document does not hold", func(t *testing.T) {
+		ctx := newConvertCtx()
+		ctx.components = components
+		assert.Nil(t, ctx.resolveTarget(base.CreateSchemaProxyRef("#/components/schemas/Missing")))
+		assert.Nil(t, ctx.resolveTarget(base.CreateSchemaProxyRef("https://example.test/other.yml#/Thing")))
+	})
+
+	t.Run("nil proxy", func(t *testing.T) {
+		ctx := newConvertCtx()
+		ctx.components = components
+		assert.Nil(t, ctx.resolveTarget(nil))
+	})
 }


### PR DESCRIPTION
OpenAPI 3.1 lets a $ref sit beside other keys, which are annotations - the reference still decides the shape. 
libopenapi returns only those siblings from such a node, so converting it directly produced a schema with no type and no properties, which the generator then rendered as a bare string.

convertProxy now looks the target up by name from the document's component schemas whenever the proxy is a reference, and converts that instead.

