### PR TITLE
Add date_between to the context functions

### DIFF
--- a/internal/contexts/fakes.go
+++ b/internal/contexts/fakes.go
@@ -3,6 +3,8 @@ package contexts
 import (
 	"reflect"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/jaswdr/faker/v2"
 	"github.com/mockzilla/mockzilla/v2/internal/types"
@@ -78,7 +80,42 @@ func getFakeFuncFactoryWith2Strings() map[string]FakeFuncFactoryWith2Strings {
 				return IntValue(fake.Int64Between(mn, mx))
 			}
 		},
+		// date_between:<from>,<to> renders a date-time between two bounds, each
+		// spelled as "now", an offset from now ("-30d", "12h"), or an absolute
+		// date ("2006-01-02"). The RFC 3339 output matches what the generator
+		// emits for a date-time format field.
+		"date_between": func(fromStr, toStr string) FakeFunc {
+			return func() MixedValue {
+				from, to := parseTimeBound(fromStr), parseTimeBound(toStr)
+				if from.After(to) {
+					from, to = to, from
+				}
+				t := fake.Time().TimeBetween(from, to)
+				return StringValue(t.UTC().Format("2006-01-02T15:04:05.000Z"))
+			}
+		},
 	}
+}
+
+// parseTimeBound reads one bound of date_between. Unreadable input means now,
+// the same shrug int_between gives a value that does not parse. A day unit is
+// handled apart because time.ParseDuration has none.
+func parseTimeBound(s string) time.Time {
+	now := time.Now()
+	if s == "" || s == "now" {
+		return now
+	}
+
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t
+	}
+	if days, err := strconv.Atoi(strings.TrimSuffix(s, "d")); err == nil && strings.HasSuffix(s, "d") {
+		return now.AddDate(0, 0, days)
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return now.Add(d)
+	}
+	return now
 }
 
 // getFakes returns a map of fake functions from underlying fake library by

--- a/internal/contexts/fakes_test.go
+++ b/internal/contexts/fakes_test.go
@@ -5,6 +5,7 @@ package contexts
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/jaswdr/faker/v2"
 	assert2 "github.com/stretchr/testify/assert"
@@ -113,6 +114,7 @@ func TestGetFakeFuncFactoryWith2Strings(t *testing.T) {
 
 	expectedKeys := []string{
 		"int_between",
+		"date_between",
 	}
 	var keys []string
 	for key := range funcs {
@@ -134,6 +136,37 @@ func TestGetFakeFuncFactoryWith2Strings(t *testing.T) {
 		fn := funcs["int_between"]("42", "42")
 		val := fn().Get().(int64)
 		assert.Equal(int64(42), val)
+	})
+
+	t.Run("date_between offset and now", func(t *testing.T) {
+		fn := funcs["date_between"]("-30d", "now")
+		for i := 0; i < 100; i++ {
+			val, err := time.Parse("2006-01-02T15:04:05.000Z", fn().Get().(string))
+			assert.NoError(err)
+			assert.True(val.After(time.Now().AddDate(0, 0, -31)), "%s is older than the window", val)
+			assert.True(val.Before(time.Now().Add(time.Minute)), "%s is in the future", val)
+		}
+	})
+
+	t.Run("date_between absolute dates", func(t *testing.T) {
+		fn := funcs["date_between"]("2024-01-01", "2024-12-31")
+		val, err := time.Parse("2006-01-02T15:04:05.000Z", fn().Get().(string))
+		assert.NoError(err)
+		assert.Equal(2024, val.Year())
+	})
+
+	t.Run("date_between swapped bounds still land inside them", func(t *testing.T) {
+		fn := funcs["date_between"]("now", "-24h")
+		val, err := time.Parse("2006-01-02T15:04:05.000Z", fn().Get().(string))
+		assert.NoError(err)
+		assert.True(val.After(time.Now().Add(-25*time.Hour)), "%s is outside the day", val)
+	})
+
+	t.Run("date_between unreadable bounds mean now", func(t *testing.T) {
+		fn := funcs["date_between"]("nonsense", "also nonsense")
+		val, err := time.Parse("2006-01-02T15:04:05.000Z", fn().Get().(string))
+		assert.NoError(err)
+		assert.WithinDuration(time.Now(), val, time.Minute)
 	})
 }
 

--- a/internal/contexts/parsers.go
+++ b/internal/contexts/parsers.go
@@ -31,7 +31,8 @@ import (
 //   - fake:path.to.func - Uses a specific faker function by path
 //   - func:name - Calls a registered no-arg function
 //   - func:name:arg - Calls a registered function with one argument
-//   - func:name:arg1,arg2 - Calls a registered function with two arguments (e.g., func:int_between:1,10)
+//   - func:name:arg1,arg2 - Calls a registered function with two arguments
+//     (func:int_between:1,10, func:date_between:-30d,now)
 //   - botify:pattern - Generates random strings based on pattern (? for letter, # for digit)
 //   - join:separator,ns.key1,ns.key2 - Joins values from multiple keys with separator
 //   - request:dotted.path - Takes the value from the incoming request payload


### PR DESCRIPTION
## Why

A context that wants a plausible timestamp - a capture from the last month, an expiry next year - had no function to spell one. `int_between` is the only two-argument context function, so a context file reaching for a `date_between` that does not exist ships a reference resolving to nothing - and because an unresolved reference keeps its own text as the value, generated mocks render the literal `func:date_between:-30d,now`.

## What

`func:date_between:<from>,<to>` renders a date-time between two bounds. Each bound is one of:

| Form | Example | Meaning |
|---|---|---|
| `now` | `now` | this moment |
| offset | `-30d`, `12h`, `-45m` | relative to now (days handled apart: `time.ParseDuration` has no day unit) |
| absolute | `2024-01-01` | that date |

Bounds arriving in the wrong order are swapped rather than fed to `TimeBetween` backwards, and an unreadable bound means now - the same shrug `int_between` gives a value that does not parse. Output is `2006-01-02T15:04:05.000Z` (UTC), the form the generator itself emits for a `date-time` field, so a context value and a generated one read alike.

## Tests

Window containment over 100 draws for `-30d,now`, absolute-date bounds, swapped bounds, and unreadable bounds; the syntax doc in `parsers.go` gains the example. `go test ./internal/... ./pkg/...` (20 packages) and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)