### PR TITLE
Drop browser headers where they are noise

### DIFF
--- a/pkg/middleware/cache_write.go
+++ b/pkg/middleware/cache_write.go
@@ -48,7 +48,7 @@ func CreateCacheWriteMiddleware(params *Params) func(http.Handler) http.Handler 
 					Method:     req.Method,
 					URL:        req.URL.String(),
 					Body:       requestBody,
-					Headers:    db.FlattenHeaders(req.Header),
+					Headers:    historyHeaders(req.Header),
 					RemoteAddr: req.RemoteAddr,
 					RequestID:  requestID,
 				}

--- a/pkg/middleware/config_override.go
+++ b/pkg/middleware/config_override.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/mockzilla/mockzilla/v2/pkg/config"
+	"github.com/mockzilla/mockzilla/v2/pkg/db"
 )
 
 // Header prefix and names for per-request config overrides.
@@ -31,8 +32,11 @@ const (
 
 const sourceUI = "ui"
 
-// browserHeaders are headers automatically added by browsers that add noise
-// to history and should not be forwarded upstream.
+// browserHeaders are headers a browser adds on its own. They say nothing about
+// the call, so history leaves them out and they are not forwarded upstream. They
+// are not removed from the request: a service whose spec declares one - Accept-
+// Language is a parameter of several published APIs - has to be able to read
+// what the caller sent.
 var browserHeaders = map[string]bool{
 	"Origin":                            true,
 	"Referer":                           true,
@@ -69,25 +73,31 @@ func CreateConfigOverrideMiddleware(params *Params) func(http.Handler) http.Hand
 				req = req.WithContext(ctx)
 			}
 
-			fromUI := req.Header.Get(headerPrefix+headerSource) == sourceUI
-			stripBrowserHeaders(req, fromUI)
+			if req.Header.Get(headerPrefix+headerSource) == sourceUI {
+				req.Header.Del("Authorization")
+			}
 			next.ServeHTTP(w, req)
 		})
 	}
 }
 
-// stripBrowserHeaders removes known browser-injected headers from the request.
-// When the request originates from the UI (detected by the presence of X-Mockzilla-*
-// headers), Authorization is also stripped since it belongs to the UI session,
-// not to the target API.
-func stripBrowserHeaders(req *http.Request, fromUI bool) {
-	for name := range req.Header {
-		canonical := http.CanonicalHeaderKey(name)
-		if browserHeaders[canonical] {
-			req.Header.Del(name)
-			continue
+// historyHeaders is what a request contributes to history: what the caller sent,
+// less the headers a browser added for them.
+func historyHeaders(h http.Header) []string {
+	kept := make(http.Header, len(h))
+	for name, values := range h {
+		if !browserHeaders[http.CanonicalHeaderKey(name)] {
+			kept[name] = values
 		}
-		if fromUI && canonical == "Authorization" {
+	}
+	return db.FlattenHeaders(kept)
+}
+
+// dropBrowserHeaders removes what a browser added from a request about to be
+// forwarded upstream. The caller's own headers are left alone.
+func dropBrowserHeaders(req *http.Request) {
+	for name := range req.Header {
+		if browserHeaders[http.CanonicalHeaderKey(name)] {
 			req.Header.Del(name)
 		}
 	}

--- a/pkg/middleware/config_override_test.go
+++ b/pkg/middleware/config_override_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -329,7 +330,7 @@ func TestCreateConfigOverrideMiddleware(t *testing.T) {
 		assert.Equal("eyJmb28iOiJiYXIifQ==", capturedHeaders.Get("X-Mockzilla-Context"))
 	})
 
-	t.Run("browser headers are stripped from request", func(t *testing.T) {
+	t.Run("browser headers reach the handler", func(t *testing.T) {
 		params := newTestParams(&config.ServiceConfig{Name: "test"})
 
 		var capturedHeaders http.Header
@@ -342,27 +343,47 @@ func TestCreateConfigOverrideMiddleware(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer 123")
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Origin", "http://localhost:2200")
-		req.Header.Set("Referer", "http://localhost:2200/ui")
-		req.Header.Set("Cookie", "session=abc")
-		req.Header.Set("Sec-Fetch-Mode", "cors")
-		req.Header.Set("Sec-Fetch-Site", "same-origin")
-		req.Header.Set("Sec-Ch-Ua", "\"Chromium\";v=\"130\"")
 		req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 		w := NewBufferedResponseWriter()
 
 		mw := CreateConfigOverrideMiddleware(params)
 		mw(handler).ServeHTTP(w, req)
 
-		// Authorization is preserved when request is not from UI
+		// A service whose spec declares one has to be able to read it.
 		assert.Equal("Bearer 123", capturedHeaders.Get("Authorization"))
 		assert.Equal("application/json", capturedHeaders.Get("Content-Type"))
-		assert.Empty(capturedHeaders.Get("Origin"))
-		assert.Empty(capturedHeaders.Get("Referer"))
-		assert.Empty(capturedHeaders.Get("Cookie"))
-		assert.Empty(capturedHeaders.Get("Sec-Fetch-Mode"))
-		assert.Empty(capturedHeaders.Get("Sec-Fetch-Site"))
-		assert.Empty(capturedHeaders.Get("Sec-Ch-Ua"))
-		assert.Empty(capturedHeaders.Get("Accept-Language"))
+		assert.Equal("http://localhost:2200", capturedHeaders.Get("Origin"))
+		assert.Equal("en-US,en;q=0.9", capturedHeaders.Get("Accept-Language"))
+	})
+
+	t.Run("browser headers stay out of history", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Content-Type", "application/json")
+		h.Set("Authorization", "Bearer 123")
+		h.Set("Accept-Language", "en-US,en;q=0.9")
+		h.Set("Sec-Fetch-Mode", "cors")
+		h.Set("Origin", "http://localhost:2200")
+
+		kept := strings.Join(historyHeaders(h), "\n")
+
+		assert.Contains(kept, "Content-Type")
+		assert.Contains(kept, "Authorization")
+		assert.NotContains(kept, "Accept-Language")
+		assert.NotContains(kept, "Sec-Fetch-Mode")
+		assert.NotContains(kept, "Origin")
+	})
+
+	t.Run("browser headers are not forwarded upstream", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+		req.Header.Set("Sec-Fetch-Mode", "cors")
+
+		cleanUpstreamHeaders(req)
+
+		assert.Equal("application/json", req.Header.Get("Content-Type"))
+		assert.Empty(req.Header.Get("Accept-Language"))
+		assert.Empty(req.Header.Get("Sec-Fetch-Mode"))
 	})
 
 	t.Run("Authorization is stripped when request comes from UI", func(t *testing.T) {
@@ -384,8 +405,10 @@ func TestCreateConfigOverrideMiddleware(t *testing.T) {
 		mw := CreateConfigOverrideMiddleware(params)
 		mw(handler).ServeHTTP(w, req)
 
+		// The UI's own credential is not the target API's, so it does not reach it.
+		// Everything else the browser sent does; it is only noise to history.
 		assert.Empty(capturedHeaders.Get("Authorization"))
-		assert.Empty(capturedHeaders.Get("Origin"))
+		assert.Equal("http://localhost:2200", capturedHeaders.Get("Origin"))
 		assert.Equal("application/json", capturedHeaders.Get("Content-Type"))
 		assert.Equal("ui", capturedHeaders.Get("X-Mockzilla-Source"))
 	})

--- a/pkg/middleware/upstream.go
+++ b/pkg/middleware/upstream.go
@@ -108,7 +108,7 @@ func CreateUpstreamRequestMiddleware(params *Params) func(http.Handler) http.Han
 						histReq := &db.HistoryRequest{
 							Method:     req.Method,
 							URL:        req.URL.String(),
-							Headers:    db.FlattenHeaders(req.Header),
+							Headers:    historyHeaders(req.Header),
 							RemoteAddr: req.RemoteAddr,
 							RequestID:  requestID,
 						}
@@ -237,7 +237,7 @@ func getUpstreamResponse(log *slog.Logger, svcCfg *config.ServiceConfig, cfg *co
 			Method:     req.Method,
 			URL:        req.URL.String(),
 			Body:       bodyBytes,
-			Headers:    db.FlattenHeaders(req.Header),
+			Headers:    historyHeaders(req.Header),
 			RemoteAddr: req.RemoteAddr,
 			RequestID:  GetRequestID(req),
 		}
@@ -271,6 +271,10 @@ func getUpstreamResponse(log *slog.Logger, svcCfg *config.ServiceConfig, cfg *co
 // only the listed headers are kept (all others are removed).
 func cleanUpstreamHeaders(req *http.Request) {
 	allowList := req.Header.Get(headerPrefix + headerUpstreamHeaders)
+
+	if allowList == "" {
+		dropBrowserHeaders(req)
+	}
 
 	if allowList != "" {
 		allowed := parseUpstreamHeadersList(allowList)


### PR DESCRIPTION
Nineteen headers a browser sets were deleted from every request before any handler ran. A service whose spec declares one could not read what the caller sent: Accept-Language is an operation parameter of plenty of
published APIs, and an operation that takes it was answered as though it had never been given.

The strip existed for the two reasons its own comment named, and neither is the handler's: those headers crowd out the ones that matter in history, and they should not be forwarded upstream. Both are done at those two points now, and the request carries what arrived.

The UI's Authorization is still removed. That one is not noise, it is the UI session's credential rather than the target API's, and it should not be mistakeable for one.
