### PR TITLE
Stop holding the parsed spec after a service boots

### DIFF
--- a/cmd/api/service.go
+++ b/cmd/api/service.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"compress/gzip"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -167,7 +168,8 @@ func GenerateService(opts ServiceOptions) error {
 		return fmt.Errorf("reading spec file: %w", err)
 	}
 
-	// If spec was fetched from URL, save it locally for //go:embed to work
+	// If spec was fetched from URL, save it locally so it stays alongside the
+	// service for regeneration and review
 	if files.IsURL(specFile) {
 		specExt := ".yml"
 		if files.IsJsonType(specContents) {
@@ -219,6 +221,19 @@ func GenerateService(opts ServiceOptions) error {
 	serviceCfg, err := config.NewServiceConfigFromBytes(serviceCfgContents)
 	if err != nil {
 		return fmt.Errorf("parsing service config: %w", err)
+	}
+
+	// Only the generated handler embeds the spec, and only it reads the flag.
+	compressSpec := serviceCfg.SpecOptions != nil && serviceCfg.SpecOptions.Compress &&
+		cfg.Generate != nil && cfg.Generate.Handler != nil
+	if compressSpec {
+		if err := writeCompressedSpec(setupDir, specContents); err != nil {
+			return err
+		}
+		if cfg.UserContext == nil {
+			cfg.UserContext = make(map[string]any)
+		}
+		cfg.UserContext["CompressedSpec"] = true
 	}
 
 	// Parse OpenAPI spec
@@ -682,6 +697,27 @@ func handleSetupSourceSpec(opts ServiceOptions, setupDir, serviceName, serviceTy
 
 	if !opts.Quiet {
 		fmt.Printf("Copied spec file to: %s\n", specPath)
+	}
+	return nil
+}
+
+// writeCompressedSpec writes the gzipped spec the generated service embeds.
+func writeCompressedSpec(setupDir string, specContents []byte) error {
+	var buf bytes.Buffer
+	zw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("creating gzip writer: %w", err)
+	}
+	if _, err := zw.Write(specContents); err != nil {
+		return fmt.Errorf("compressing spec: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("closing gzip writer: %w", err)
+	}
+
+	dest := filepath.Join(setupDir, "spec.gz")
+	if err := os.WriteFile(dest, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("writing compressed spec to %s: %w", dest, err)
 	}
 	return nil
 }

--- a/cmd/api/service_test.go
+++ b/cmd/api/service_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteCompressedSpec(t *testing.T) {
+	spec := []byte("openapi: 3.0.0\ninfo:\n  title: t\n  version: 1\npaths: {}\n")
+
+	readBack := func(t *testing.T, dir string) []byte {
+		t.Helper()
+		f, err := os.Open(filepath.Join(dir, "spec.gz"))
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+
+		zr, err := gzip.NewReader(f)
+		require.NoError(t, err)
+		defer func() { _ = zr.Close() }()
+
+		out, err := io.ReadAll(zr)
+		require.NoError(t, err)
+		return out
+	}
+
+	t.Run("writes a spec.gz that decompresses to the input", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, writeCompressedSpec(dir, spec))
+		assert.Equal(t, spec, readBack(t, dir))
+	})
+
+	t.Run("leaves the plain spec name untouched", func(t *testing.T) {
+		// The generated service embeds setup/spec.gz; a name matching the
+		// setup/openapi.* glob older services embed would feed them gzip bytes.
+		dir := t.TempDir()
+		require.NoError(t, writeCompressedSpec(dir, spec))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "spec.gz", entries[0].Name())
+	})
+
+	t.Run("overwrites a stale spec.gz", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.gz"), []byte("stale"), 0644))
+		require.NoError(t, writeCompressedSpec(dir, spec))
+		assert.Equal(t, spec, readBack(t, dir))
+	})
+
+	t.Run("compresses a repetitive spec well below its source size", func(t *testing.T) {
+		dir := t.TempDir()
+		large := make([]byte, 0, 64*1024)
+		for len(large) < 64*1024 {
+			large = append(large, "    description: a repeated schema description\n"...)
+		}
+		require.NoError(t, writeCompressedSpec(dir, large))
+
+		info, err := os.Stat(filepath.Join(dir, "spec.gz"))
+		require.NoError(t, err)
+		assert.Less(t, info.Size(), int64(len(large))/4)
+		assert.Equal(t, large, readBack(t, dir))
+	})
+
+	t.Run("errors when the setup directory does not exist", func(t *testing.T) {
+		err := writeCompressedSpec(filepath.Join(t.TempDir(), "missing"), spec)
+		require.Error(t, err)
+	})
+}

--- a/cmd/api/templates/handler/chi/handler.tmpl
+++ b/cmd/api/templates/handler/chi/handler.tmpl
@@ -85,7 +85,11 @@ func NewRouter(svc {{ $serviceName }}Interface, opts ...RouterOption) chi.Router
 //go:embed setup/config.yml
 var configSrc []byte
 
+{{- if and $config.UserContext (index $config.UserContext "CompressedSpec") }}
+//go:embed setup/spec.gz
+{{- else }}
 //go:embed setup/openapi.*
+{{- end }}
 var openapiSpecFS embed.FS
 
 //go:embed setup/context.yml
@@ -125,7 +129,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -147,6 +151,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -183,19 +190,6 @@ func RegisterAPIRouter(router *api.Router) {
 	)
 }
 
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
-}
 {{- if $config.UserContext }}{{- with index $config.UserContext "Overlays" }}
 
 // applyOverlays applies the inlined overlay documents to the OpenAPI spec bytes.
@@ -364,7 +358,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/api/templates/setup/config.yml
+++ b/cmd/api/templates/setup/config.yml
@@ -8,6 +8,9 @@ cache:
   requests: true
 spec:
   simplify: false
+  # compress: true embeds the spec gzipped and writes setup/spec.gz, which then
+  # has to be committed with the generated code
+  compress: false
   # optional-properties not set = keep all optional properties
   # optional-properties:
   #   min: 5

--- a/docs/commands/service.md
+++ b/docs/commands/service.md
@@ -51,7 +51,9 @@ The command creates a service directory with this structure:
 │   ├── codegen.yml      # Code generation settings
 │   ├── config.yml       # Service runtime configuration
 │   ├── context.yml      # Context variables for response generation
-│   └── openapi.yml      # OpenAPI spec (only if local path was provided)
+│   ├── openapi.yml      # OpenAPI spec (only if local path was provided)
+│   └── spec.gz          # Gzipped spec, embedded in place of the plain one
+│                        # (only when spec.compress is enabled; commit it)
 ├── types/               # Generated Go types
 ├── handler/             # Generated request handlers
 ├── register.go          # Service registration

--- a/docs/config/service.md
+++ b/docs/config/service.md
@@ -138,6 +138,7 @@ replay:
 # OpenAPI spec simplification
 spec:
   simplify: false
+  compress: false
   # optional-properties not set = keep all optional properties
   # optional-properties:
   #   min: 5
@@ -254,6 +255,29 @@ spec:
 
 When `optional-properties` is not set, all optional properties are kept.
 This helps with specs that have schemas with many optional fields.
+
+## Spec Compression
+
+A generated service embeds its OpenAPI spec so it can produce mock data at
+runtime. Set `compress` to embed that spec gzipped instead of verbatim:
+
+```yaml
+spec:
+  compress: true   # default: false
+```
+
+This shrinks the generated binary, typically to around a tenth of the embedded
+spec's size, and costs a few milliseconds at startup to expand.
+
+It is off by default because `//go:embed` resolves at compile time, so the
+compressed spec is a build input rather than a build output. With `compress`
+enabled, `mockzilla service generate` writes `setup/spec.gz` next to your
+`setup/openapi.yml`, and that file has to be committed along with the generated
+code: `go build` fails without it. The plain spec stays on disk for reading and
+regeneration but is no longer embedded.
+
+Turn it on for a project where binary size matters more than keeping a binary
+file out of version control. Existing services are unaffected until regenerated.
 
 ## Upstream Proxy
 

--- a/examples/commands/service/petstore/gen.go
+++ b/examples/commands/service/petstore/gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path"
 	"time"
 
 	"sync"
@@ -1750,7 +1749,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -1761,6 +1760,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -1795,20 +1797,6 @@ func RegisterAPIRouter(router *api.Router) {
 	slog.Info(fmt.Sprintf("Registered %s service", serviceName),
 		"service", serviceName,
 	)
-}
-
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
 }
 
 // ============================================================================
@@ -2370,7 +2358,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/commands/service/static/gen.go
+++ b/examples/commands/service/static/gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path"
 
 	"sync"
 
@@ -264,7 +263,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -275,6 +274,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -309,20 +311,6 @@ func RegisterAPIRouter(router *api.Router) {
 	slog.Info(fmt.Sprintf("Registered %s service", serviceName),
 		"service", serviceName,
 	)
-}
-
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
 }
 
 // ============================================================================
@@ -436,7 +424,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/commands/service/users/gen.go
+++ b/examples/commands/service/users/gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path"
 
 	"sync"
 
@@ -729,7 +728,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -740,6 +739,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -774,20 +776,6 @@ func RegisterAPIRouter(router *api.Router) {
 	slog.Info(fmt.Sprintf("Registered %s service", serviceName),
 		"service", serviceName,
 	)
-}
-
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
 }
 
 // ============================================================================
@@ -1158,7 +1146,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/commands/service/zero-endpoints/gen.go
+++ b/examples/commands/service/zero-endpoints/gen.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path"
 
 	"sync"
 
@@ -196,7 +195,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -207,6 +206,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -241,20 +243,6 @@ func RegisterAPIRouter(router *api.Router) {
 	slog.Info(fmt.Sprintf("Registered %s service", serviceName),
 		"service", serviceName,
 	)
-}
-
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
 }
 
 // ============================================================================
@@ -343,7 +331,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/docker-compose/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/petstore/gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path"
 	"time"
 
 	"sync"
@@ -1331,7 +1330,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -1342,6 +1341,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -1376,20 +1378,6 @@ func RegisterAPIRouter(router *api.Router) {
 	slog.Info(fmt.Sprintf("Registered %s service", serviceName),
 		"service", serviceName,
 	)
-}
-
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
 }
 
 // ============================================================================
@@ -1951,7 +1939,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker-compose/pre-generated-services/services/spoonacular/gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path"
 
 	"sync"
 
@@ -11045,7 +11044,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -11056,6 +11055,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -11090,20 +11092,6 @@ func RegisterAPIRouter(router *api.Router) {
 	slog.Info(fmt.Sprintf("Registered %s service", serviceName),
 		"service", serviceName,
 	)
-}
-
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
 }
 
 // ============================================================================
@@ -13645,7 +13633,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/docker/pre-generated-services/services/petstore/gen.go
+++ b/examples/docker/pre-generated-services/services/petstore/gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path"
 	"time"
 
 	"sync"
@@ -1331,7 +1330,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -1342,6 +1341,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -1376,20 +1378,6 @@ func RegisterAPIRouter(router *api.Router) {
 	slog.Info(fmt.Sprintf("Registered %s service", serviceName),
 		"service", serviceName,
 	)
-}
-
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
 }
 
 // ============================================================================
@@ -1951,7 +1939,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/docker/pre-generated-services/services/spoonacular/gen.go
+++ b/examples/docker/pre-generated-services/services/spoonacular/gen.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"path"
 
 	"sync"
 
@@ -11045,7 +11044,7 @@ func RegisterAPIRouter(router *api.Router) {
 	serviceName := cfg.Name
 
 	// Read OpenAPI spec from embedded FS
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to read OpenAPI spec for %s", serviceName),
 			"error", err,
@@ -11056,6 +11055,9 @@ func RegisterAPIRouter(router *api.Router) {
 
 	registry, err := typedef.NewRegistry(openapiSpec, typedef.RegistryOptions{
 		SpecOptions: cfg.SpecOptions,
+		// The served request path reads converted operations only, so the
+		// parsed document does not need to stay resident.
+		ReleaseDocument: true,
 	})
 	if err != nil {
 		slog.Error(fmt.Sprintf("Failed to create registry for %s", serviceName),
@@ -11090,20 +11092,6 @@ func RegisterAPIRouter(router *api.Router) {
 	slog.Info(fmt.Sprintf("Registered %s service", serviceName),
 		"service", serviceName,
 	)
-}
-
-// readFirstEmbeddedFile reads the first file from an embedded filesystem.
-func readFirstEmbeddedFile(fsys embed.FS) ([]byte, error) {
-	entries, err := fsys.ReadDir("setup")
-	if err != nil {
-		return nil, fmt.Errorf("reading embedded directory: %w", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			return fsys.ReadFile(path.Join("setup", entry.Name()))
-		}
-	}
-	return nil, errors.New("no file found in embedded filesystem")
 }
 
 // ============================================================================
@@ -13645,7 +13633,7 @@ var (
 // spec options, and context.
 // Use it to generate mock requests and responses programmatically without running the server.
 func NewFactory(opts ...factory.FactoryOption) (*factory.Factory, error) {
-	openapiSpec, err := readFirstEmbeddedFile(openapiSpecFS)
+	openapiSpec, err := api.ReadEmbeddedSpec(openapiSpecFS)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/embedded_spec.go
+++ b/pkg/api/embedded_spec.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"strings"
+)
+
+const specSetupDir = "setup"
+
+// ReadEmbeddedSpec reads the OpenAPI spec a generated service embeds, expanding
+// it when the service was generated with spec compression enabled. The embed
+// pattern decides which single file is present.
+func ReadEmbeddedSpec(fsys fs.FS) ([]byte, error) {
+	entries, err := fs.ReadDir(fsys, specSetupDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading embedded directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		return readSpecFile(fsys, path.Join(specSetupDir, entry.Name()))
+	}
+
+	return nil, errors.New("no file found in embedded filesystem")
+}
+
+func readSpecFile(fsys fs.FS, name string) ([]byte, error) {
+	f, err := fsys.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	if !strings.HasSuffix(name, ".gz") {
+		return io.ReadAll(f)
+	}
+
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("decompressing embedded spec %s: %w", name, err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	return io.ReadAll(zr)
+}

--- a/pkg/api/embedded_spec_test.go
+++ b/pkg/api/embedded_spec_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failOpenFS lists its entries but refuses to open one of them. Embedding the
+// fs.FS interface keeps ReadDirFS unpromoted, so directory reads fall back to
+// Open and still succeed.
+type failOpenFS struct {
+	fs.FS
+	fail string
+}
+
+func (f failOpenFS) Open(name string) (fs.File, error) {
+	if name == f.fail {
+		return nil, fs.ErrPermission
+	}
+	return f.FS.Open(name)
+}
+
+func TestReadEmbeddedSpec(t *testing.T) {
+	spec := []byte("openapi: 3.0.0\ninfo:\n  title: t\n  version: 1\npaths: {}\n")
+
+	gzipped := func(t *testing.T, payload []byte) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
+		_, err := zw.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, zw.Close())
+		return buf.Bytes()
+	}
+
+	t.Run("reads a plain yaml spec", func(t *testing.T) {
+		got, err := ReadEmbeddedSpec(fstest.MapFS{"setup/openapi.yml": {Data: spec}})
+		require.NoError(t, err)
+		assert.Equal(t, spec, got)
+	})
+
+	t.Run("reads a plain json spec", func(t *testing.T) {
+		got, err := ReadEmbeddedSpec(fstest.MapFS{"setup/openapi.json": {Data: spec}})
+		require.NoError(t, err)
+		assert.Equal(t, spec, got)
+	})
+
+	t.Run("expands a compressed spec", func(t *testing.T) {
+		got, err := ReadEmbeddedSpec(fstest.MapFS{"setup/spec.gz": {Data: gzipped(t, spec)}})
+		require.NoError(t, err)
+		assert.Equal(t, spec, got)
+	})
+
+	t.Run("errors when nothing is embedded", func(t *testing.T) {
+		_, err := ReadEmbeddedSpec(fstest.MapFS{})
+		require.Error(t, err)
+	})
+
+	t.Run("errors when the setup directory holds only subdirectories", func(t *testing.T) {
+		_, err := ReadEmbeddedSpec(fstest.MapFS{"setup/data/index.json": {Data: []byte("{}")}})
+		require.Error(t, err)
+	})
+
+	t.Run("propagates a failure to open the embedded file", func(t *testing.T) {
+		fsys := failOpenFS{
+			FS:   fstest.MapFS{"setup/openapi.yml": {Data: spec}},
+			fail: "setup/openapi.yml",
+		}
+
+		_, err := ReadEmbeddedSpec(fsys)
+		require.ErrorIs(t, err, fs.ErrPermission)
+	})
+
+	t.Run("errors when a .gz payload is not gzip", func(t *testing.T) {
+		_, err := ReadEmbeddedSpec(fstest.MapFS{"setup/spec.gz": {Data: spec}})
+		require.Error(t, err)
+	})
+}

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -720,8 +720,13 @@ func NewCacheConfig() *CacheConfig {
 //	    min: 2        # Keep random number between 2-8 optional properties
 //	    max: 8
 type SpecOptions struct {
-	LazyLoad           bool                `yaml:"lazyLoad"`
-	Simplify           bool                `yaml:"simplify"`
+	LazyLoad bool `yaml:"lazyLoad"`
+	Simplify bool `yaml:"simplify"`
+
+	// Compress embeds the spec gzipped instead of verbatim, shrinking the
+	// binary at the cost of a generated setup/spec.gz that has to be committed
+	// alongside the generated code, since //go:embed resolves at compile time.
+	Compress           bool                `yaml:"compress"`
 	OptionalProperties *OptionalProperties `yaml:"optional-properties"`
 }
 

--- a/pkg/config/service_test.go
+++ b/pkg/config/service_test.go
@@ -45,6 +45,31 @@ cache:
 		assert.True(t, cfg.Cache.Requests)
 	})
 
+	t.Run("Parses spec compression opt-in", func(t *testing.T) {
+		yamlData := []byte(`
+spec:
+  simplify: false
+  compress: true
+`)
+
+		cfg, err := NewServiceConfigFromBytes(yamlData)
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg.SpecOptions)
+		assert.True(t, cfg.SpecOptions.Compress)
+	})
+
+	t.Run("Leaves spec compression off when unset", func(t *testing.T) {
+		yamlData := []byte(`
+spec:
+  simplify: true
+`)
+
+		cfg, err := NewServiceConfigFromBytes(yamlData)
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg.SpecOptions)
+		assert.False(t, cfg.SpecOptions.Compress)
+	})
+
 	t.Run("Returns error for invalid YAML", func(t *testing.T) {
 		yamlData := []byte(`invalid: yaml: data: [`)
 

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -120,8 +120,11 @@ func NewFactory(specBytes []byte, opts ...FactoryOption) (*Factory, error) {
 func (f *Factory) Document() (libopenapi.Document, error) {
 	f.docOnce.Do(func() {
 		if dp, ok := f.registry.(typedef.DocumentProvider); ok {
-			f.doc, f.docErr = dp.Document()
-			return
+			// A registry that released its document falls through and re-parses.
+			if doc, err := dp.Document(); err == nil && doc != nil {
+				f.doc = doc
+				return
+			}
 		}
 		if f.logger != nil {
 			cfg := datamodel.NewDocumentConfiguration()

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/mockzilla/mockzilla/v2/pkg/config"
+	"github.com/mockzilla/mockzilla/v2/pkg/typedef"
+	"github.com/pb33f/libopenapi"
 	assert2 "github.com/stretchr/testify/assert"
 )
 
@@ -110,6 +112,38 @@ func TestFactory_Document(t *testing.T) {
 		assert.NoError(err)
 		assert.NotNil(doc)
 	})
+
+	t.Run("re-parses when the registry released its document", func(t *testing.T) {
+		spec := loadTestSpec(t, "factory-test.yml")
+		f, err := NewFactory(spec)
+		assert.NoError(err)
+		f.registry = releasedRegistry{f.registry}
+
+		doc, err := f.Document()
+		assert.NoError(err)
+		assert.NotNil(doc)
+	})
+
+	t.Run("re-parses through the custom logger when the document was released", func(t *testing.T) {
+		spec := loadTestSpec(t, "factory-test.yml")
+		f, err := NewFactory(spec, WithLogger(slog.Default()))
+		assert.NoError(err)
+		f.registry = releasedRegistry{f.registry}
+
+		doc, err := f.Document()
+		assert.NoError(err)
+		assert.NotNil(doc)
+	})
+}
+
+// releasedRegistry stands in for a registry built with ReleaseDocument, whose
+// Document reports the parsed document is gone.
+type releasedRegistry struct {
+	typedef.OperationRegistry
+}
+
+func (releasedRegistry) Document() (libopenapi.Document, error) {
+	return nil, typedef.ErrDocumentReleased
 }
 
 func TestFactory_Response(t *testing.T) {

--- a/pkg/typedef/errors.go
+++ b/pkg/typedef/errors.go
@@ -1,0 +1,9 @@
+package typedef
+
+import "github.com/mockzilla/mockzilla/v2/pkg/typedef/internal/libopenapi"
+
+var (
+	// ErrDocumentReleased reports that the registry dropped its parsed document
+	// to reclaim the memory it pinned. Callers needing the document re-parse.
+	ErrDocumentReleased = libopenapi.ErrDocumentReleased
+)

--- a/pkg/typedef/internal/libopenapi/errors.go
+++ b/pkg/typedef/internal/libopenapi/errors.go
@@ -1,0 +1,9 @@
+package libopenapi
+
+import "errors"
+
+var (
+	// ErrDocumentReleased reports that the registry dropped its parsed document
+	// to reclaim the memory it pinned.
+	ErrDocumentReleased = errors.New("openapi document released")
+)

--- a/pkg/typedef/internal/libopenapi/registry.go
+++ b/pkg/typedef/internal/libopenapi/registry.go
@@ -25,12 +25,19 @@ import (
 type Options struct {
 	SpecOptions *config.SpecOptions
 	Logger      *slog.Logger
+
+	// ReleaseDocument drops the parsed document and v3 model once every
+	// operation is converted, trading [Registry.Document] for the memory they
+	// pin for the process lifetime. Ignored unless SpecOptions disables
+	// LazyLoad, since a later conversion would need the model back.
+	ReleaseDocument bool
 }
 
 // Registry is the libopenapi-backed runtime registry.
 type Registry struct {
-	doc   libopenapi.Document
-	model *v3.Document
+	doc      libopenapi.Document
+	model    *v3.Document
+	released bool
 
 	routes          []schema.RouteInfo
 	index           map[string]*opEntry
@@ -87,6 +94,9 @@ func NewRegistry(specBytes []byte, opts Options) (*Registry, error) {
 		for _, e := range reg.index {
 			reg.convertEntry(e)
 		}
+		if opts.ReleaseDocument {
+			reg.release()
+		}
 	}
 
 	return reg, nil
@@ -130,8 +140,25 @@ func (r *Registry) GetResponseSchema(path, method string) *schema.ResponseSchema
 
 // Document returns the parsed libopenapi document so callers (like
 // pkg/factory) can hand it to the libopenapi-validator without re-parsing.
+// It errors when the document was released, so callers re-parse rather than
+// silently treating a nil document as a spec that declares nothing.
 func (r *Registry) Document() (libopenapi.Document, error) {
+	if r.released {
+		return nil, ErrDocumentReleased
+	}
 	return r.doc, nil
+}
+
+// release drops every reference into libopenapi once conversion is done.
+// opEntry.op has to go too: the index would otherwise keep the whole v3 model
+// reachable and free nothing.
+func (r *Registry) release() {
+	for _, e := range r.index {
+		e.op = nil
+	}
+	r.doc = nil
+	r.model = nil
+	r.released = true
 }
 
 // componentSchemas is the document's schema components, or nil when it declares

--- a/pkg/typedef/internal/libopenapi/registry_test.go
+++ b/pkg/typedef/internal/libopenapi/registry_test.go
@@ -74,6 +74,45 @@ func TestNewRegistry_EagerPreConvertsAll(t *testing.T) {
 	assert.Len(t, reg.Operations(), 3, "eager mode pre-converts every op")
 }
 
+func TestNewRegistry_ReleaseDocumentKeepsOperations(t *testing.T) {
+	spec := readSpec(t, filepath.Join("..", "..", "..", "..", "internal", "portable", "testdata", "petstore.yml"))
+
+	reg, err := NewRegistry(spec, Options{
+		SpecOptions:     &config.SpecOptions{LazyLoad: false},
+		ReleaseDocument: true,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, reg.Operations(), 3)
+	assert.Len(t, reg.GetRouteInfo(), 3)
+	require.NotNil(t, reg.FindOperation("/pets", "GET"))
+	require.NotNil(t, reg.GetResponseSchema("/pets", "GET"))
+
+	assert.Nil(t, reg.model)
+	assert.Nil(t, reg.doc)
+	for key, e := range reg.index {
+		assert.Nil(t, e.op, "index entry %s still pins the v3 model", key)
+	}
+
+	_, err = reg.Document()
+	require.ErrorIs(t, err, ErrDocumentReleased)
+}
+
+func TestNewRegistry_ReleaseDocumentIgnoredWhenLazy(t *testing.T) {
+	spec := readSpec(t, filepath.Join("..", "..", "..", "..", "internal", "portable", "testdata", "petstore.yml"))
+
+	reg, err := NewRegistry(spec, Options{
+		SpecOptions:     &config.SpecOptions{LazyLoad: true},
+		ReleaseDocument: true,
+	})
+	require.NoError(t, err)
+
+	doc, err := reg.Document()
+	require.NoError(t, err)
+	require.NotNil(t, doc, "lazy conversion still needs the document")
+	require.NotNil(t, reg.FindOperation("/pets", "GET"))
+}
+
 func TestNewRegistry_MissingOperationReturnsNil(t *testing.T) {
 	spec := readSpec(t, filepath.Join("..", "..", "..", "..", "internal", "portable", "testdata", "petstore.yml"))
 

--- a/pkg/typedef/registry.go
+++ b/pkg/typedef/registry.go
@@ -30,13 +30,20 @@ type DocumentProvider interface {
 type RegistryOptions struct {
 	SpecOptions *config.SpecOptions
 	Logger      *slog.Logger
+
+	// ReleaseDocument drops the parsed document and v3 model once every
+	// operation is converted. Generated services set it because their request
+	// path reads only converted operations; portable mode does not, because its
+	// validator needs the document. Ignored unless LazyLoad is off.
+	ReleaseDocument bool
 }
 
 // NewRegistry parses an OpenAPI spec and returns an OperationRegistry.
 func NewRegistry(specBytes []byte, opts RegistryOptions) (OperationRegistry, error) {
 	return libopenapi.NewRegistry(specBytes, libopenapi.Options{
-		SpecOptions: opts.SpecOptions,
-		Logger:      opts.Logger,
+		SpecOptions:     opts.SpecOptions,
+		Logger:          opts.Logger,
+		ReleaseDocument: opts.ReleaseDocument,
 	})
 }
 

--- a/pkg/typedef/registry_test.go
+++ b/pkg/typedef/registry_test.go
@@ -44,6 +44,23 @@ func TestNewRegistry_ForwardsAndImplementsInterfaces(t *testing.T) {
 	require.NotNil(t, doc)
 }
 
+func TestNewRegistry_ForwardsReleaseDocument(t *testing.T) {
+	reg, err := NewRegistry([]byte(minimalSpec), RegistryOptions{
+		SpecOptions:     &config.SpecOptions{LazyLoad: false},
+		ReleaseDocument: true,
+	})
+	require.NoError(t, err)
+
+	op := reg.FindOperation("/pets", "GET")
+	require.NotNil(t, op, "releasing the document must not lose converted operations")
+	assert.Equal(t, "listPets", op.ID)
+
+	dp, ok := reg.(DocumentProvider)
+	require.True(t, ok)
+	_, err = dp.Document()
+	require.ErrorIs(t, err, ErrDocumentReleased)
+}
+
 func TestNewRegistry_RejectsInvalidSpec(t *testing.T) {
 	_, err := NewRegistry([]byte("this: is: not: valid: openapi"), RegistryOptions{})
 	require.Error(t, err)

--- a/resources/json-schema-service.json
+++ b/resources/json-schema-service.json
@@ -148,6 +148,11 @@
           "description": "Enable spec simplification.",
           "default": false
         },
+        "compress": {
+          "type": "boolean",
+          "description": "Embed the OpenAPI spec gzipped instead of verbatim. Shrinks the generated binary; requires the generated setup/spec.gz to be committed alongside the generated code.",
+          "default": false
+        },
         "optional-properties": {
           "type": "object",
           "description": "Controls how many optional properties to keep. When not set, all optional properties are kept.",


### PR DESCRIPTION
A generated service parsed its OpenAPI spec at startup and then kept the parsed document and v3 model resident for the life of the process, though nothing on the request path reads either. 
On a Stripe-sized spec that was 322 MB of retained heap where 197 MB was the data actually in use.

Both are dropped once every operation is converted. The index entries are cleared with them: they hold the `*v3.Operation` pointers that keep the whole model reachable, so releasing the document alone frees nothing.

Portable mode keeps its document, because its validator needs it.

A generated service can now also embed its spec gzipped, off by default, under `spec.compress` in config.yml. 
It takes a Stripe-sized spec from 6.0 MB to 0.6 MB inside the binary for about 9 ms at startup, at the cost of a generated setup/spec.gz that has to be committed with the generated code, since //go:embed resolves at compile time.