### PR TITLE
Bind multipart form fields declared through a reference

### DIFF
--- a/cmd/api/multipart.go
+++ b/cmd/api/multipart.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+)
+
+const multipartPrefix = "multipart/"
+
+// inlineMultipartBodies rewrites every multipart request body whose schema is a
+// reference or an allOf into the equivalent inline object.
+//
+// oapi-codegen emits the form-field binding from the properties it finds on the
+// operation's own body schema, and a referenced schema carries none of its own.
+// The generated handler then parses the form, declares the body struct and hands
+// it over without ever writing to it, so an upload arrives as a zero value.
+//
+// It runs on the spec as written rather than on the filtered and overlaid
+// document the generator builds from, because rendering that document back to
+// bytes leaves behind references its own pruning has already removed.
+func inlineMultipartBodies(specContents []byte) ([]byte, error) {
+	doc, err := libopenapi.NewDocumentWithConfiguration(specContents, &datamodel.DocumentConfiguration{
+		SkipCircularReferenceCheck: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating document: %w", err)
+	}
+
+	model, errs := doc.BuildV3Model()
+	if errs != nil {
+		return nil, fmt.Errorf("building model: %w", errs)
+	}
+
+	rewritten := false
+	for _, item := range allPathItems(&model.Model) {
+		for _, op := range item.GetOperations().FromOldest() {
+			if inlineOperationBody(op) {
+				rewritten = true
+			}
+		}
+	}
+
+	// A spec with nothing to rewrite reaches the generator exactly as written.
+	if !rewritten {
+		return specContents, nil
+	}
+
+	indent := doc.GetSpecInfo().OriginalIndentation
+	if indent <= 0 {
+		indent = 2
+	}
+	return model.Model.RenderWithIndention(indent), nil
+}
+
+func allPathItems(model *v3high.Document) []*v3high.PathItem {
+	if model.Paths == nil || model.Paths.PathItems == nil {
+		return nil
+	}
+	return slices.Collect(model.Paths.PathItems.ValuesFromOldest())
+}
+
+func inlineOperationBody(op *v3high.Operation) bool {
+	if op == nil || op.RequestBody == nil || op.RequestBody.Content == nil {
+		return false
+	}
+
+	rewritten := false
+	for contentType, media := range op.RequestBody.Content.FromOldest() {
+		if !strings.HasPrefix(contentType, multipartPrefix) || media.Schema == nil {
+			continue
+		}
+		if inline := inlineSchema(media.Schema); inline != nil {
+			media.Schema = inline
+			rewritten = true
+		}
+	}
+	return rewritten
+}
+
+// inlineSchema returns the flattened stand-in for a body schema, or nil when the
+// generator can already see the properties.
+func inlineSchema(proxy *base.SchemaProxy) *base.SchemaProxy {
+	schema := proxy.Schema()
+	if schema == nil {
+		return nil
+	}
+	if !proxy.IsReference() && len(schema.AllOf) == 0 {
+		return nil
+	}
+
+	properties := orderedmap.New[string, *base.SchemaProxy]()
+	var required []string
+	collectProperties(schema, properties, &required, make(map[*base.Schema]bool))
+	if properties.Len() == 0 {
+		return nil
+	}
+
+	return base.CreateSchemaProxy(&base.Schema{
+		Type:        []string{"object"},
+		Description: schema.Description,
+		Properties:  properties,
+		Required:    required,
+	})
+}
+
+func collectProperties(schema *base.Schema, into *orderedmap.Map[string, *base.SchemaProxy], required *[]string, seen map[*base.Schema]bool) {
+	if schema == nil || seen[schema] {
+		return
+	}
+	seen[schema] = true
+
+	for _, member := range schema.AllOf {
+		collectProperties(member.Schema(), into, required, seen)
+	}
+
+	for name, prop := range schema.Properties.FromOldest() {
+		into.Set(name, prop)
+	}
+
+	for _, name := range schema.Required {
+		if !slices.Contains(*required, name) {
+			*required = append(*required, name)
+		}
+	}
+}

--- a/cmd/api/multipart_test.go
+++ b/cmd/api/multipart_test.go
@@ -1,0 +1,250 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInlineMultipartBodies(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+		want        []string
+		wantSame    bool
+	}{
+		{
+			name:     "inline properties are left alone",
+			body:     "type: object\n              properties:\n                kind: {type: string}",
+			wantSame: true,
+		},
+		{
+			name:        "json body is left alone",
+			contentType: "application/json",
+			body:        "$ref: '#/components/schemas/uploader'",
+			wantSame:    true,
+		},
+		{
+			name: "referenced schema is inlined",
+			body: "$ref: '#/components/schemas/uploader'",
+			want: []string{"kind", "file"},
+		},
+		{
+			name: "allOf members are merged",
+			body: "$ref: '#/components/schemas/composed'",
+			want: []string{"kind", "file", "extra"},
+		},
+		{
+			name: "allOf wrapping a reference is merged",
+			body: "allOf:\n                - $ref: '#/components/schemas/uploader'",
+			want: []string{"kind", "file"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			contentType := tc.contentType
+			if contentType == "" {
+				contentType = "multipart/form-data"
+			}
+			spec := []byte(uploadSpec(contentType, tc.body))
+
+			got, err := inlineMultipartBodies(spec)
+			require.NoError(t, err)
+
+			if tc.wantSame {
+				assert.Equal(t, spec, got, "spec should reach the generator unchanged")
+				return
+			}
+
+			schema := multipartSchema(t, got)
+			require.NotNil(t, schema)
+			assert.False(t, schema.IsReference(), "body should no longer be a reference")
+
+			var names []string
+			for name := range schema.Schema().Properties.FromOldest() {
+				names = append(names, name)
+			}
+			assert.ElementsMatch(t, tc.want, names)
+		})
+	}
+}
+
+func TestInlineMultipartBodiesKeepsRequired(t *testing.T) {
+	spec := []byte(uploadSpec("multipart/form-data", "$ref: '#/components/schemas/composed'"))
+
+	got, err := inlineMultipartBodies(spec)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"file", "kind"}, multipartSchema(t, got).Schema().Required)
+}
+
+func TestInlineMultipartBodiesRejectsUnparseableSpec(t *testing.T) {
+	_, err := inlineMultipartBodies([]byte("not: [an, openapi, document"))
+	assert.Error(t, err)
+}
+
+func TestAllPathItems(t *testing.T) {
+	assert.Nil(t, allPathItems(&v3high.Document{}))
+
+	model := buildModel(t, []byte(uploadSpec("multipart/form-data", "type: object")))
+	assert.Len(t, allPathItems(model), 1)
+}
+
+func TestInlineOperationBody(t *testing.T) {
+	assert.False(t, inlineOperationBody(nil))
+	assert.False(t, inlineOperationBody(&v3high.Operation{}))
+	assert.False(t, inlineOperationBody(&v3high.Operation{RequestBody: &v3high.RequestBody{}}))
+
+	inline := uploadOperation(t, "multipart/form-data", "type: object\n              properties:\n                kind: {type: string}")
+	assert.False(t, inlineOperationBody(inline), "inline properties need no rewrite")
+
+	referenced := uploadOperation(t, "multipart/form-data", "$ref: '#/components/schemas/uploader'")
+	assert.True(t, inlineOperationBody(referenced))
+}
+
+func TestInlineSchema(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		body  string
+		props []string
+	}{
+		{
+			name: "inline object needs no stand-in",
+			body: "type: object\n              properties:\n                kind: {type: string}",
+		},
+		{
+			name: "reference to a schema without properties needs no stand-in",
+			body: "$ref: '#/components/schemas/empty'",
+		},
+		{
+			name:  "reference is flattened",
+			body:  "$ref: '#/components/schemas/uploader'",
+			props: []string{"kind", "file"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			op := uploadOperation(t, "multipart/form-data", tc.body)
+			got := inlineSchema(op.RequestBody.Content.GetOrZero("multipart/form-data").Schema)
+
+			if tc.props == nil {
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NotNil(t, got)
+			var names []string
+			for name := range got.Schema().Properties.FromOldest() {
+				names = append(names, name)
+			}
+			assert.ElementsMatch(t, tc.props, names)
+		})
+	}
+}
+
+func TestCollectProperties(t *testing.T) {
+	t.Run("merges nested allOf and dedupes required", func(t *testing.T) {
+		model := buildModel(t, []byte(uploadSpec("multipart/form-data", "type: object")))
+		schema := model.Components.Schemas.GetOrZero("nested").Schema()
+
+		props := orderedmap.New[string, *base.SchemaProxy]()
+		var required []string
+		collectProperties(schema, props, &required, make(map[*base.Schema]bool))
+
+		var names []string
+		for name := range props.FromOldest() {
+			names = append(names, name)
+		}
+		assert.ElementsMatch(t, []string{"kind", "file", "extra", "own"}, names)
+		assert.ElementsMatch(t, []string{"file", "kind"}, required)
+	})
+
+	t.Run("stops on a cycle", func(t *testing.T) {
+		schema := &base.Schema{Properties: orderedmap.New[string, *base.SchemaProxy]()}
+		schema.Properties.Set("kind", base.CreateSchemaProxy(&base.Schema{Type: []string{"string"}}))
+		schema.AllOf = []*base.SchemaProxy{base.CreateSchemaProxy(schema)}
+
+		props := orderedmap.New[string, *base.SchemaProxy]()
+		var required []string
+		collectProperties(schema, props, &required, make(map[*base.Schema]bool))
+
+		assert.Equal(t, 1, props.Len())
+	})
+}
+
+// uploadSpec renders a one-operation spec whose request body carries the given
+// schema, indented to sit under the content type.
+func uploadSpec(contentType, bodySchema string) string {
+	return `openapi: 3.0.3
+info:
+  title: upload
+  version: "1"
+paths:
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          ` + contentType + `:
+            schema:
+              ` + bodySchema + `
+      responses:
+        "201":
+          description: created
+components:
+  schemas:
+    empty:
+      type: object
+    uploader:
+      type: object
+      required: [file]
+      properties:
+        kind: {type: string}
+        file: {type: string, format: binary}
+    composed:
+      allOf:
+        - $ref: '#/components/schemas/uploader'
+        - type: object
+          required: [kind, file]
+          properties:
+            extra: {type: string}
+    nested:
+      allOf:
+        - $ref: '#/components/schemas/composed'
+      properties:
+        own: {type: string}
+`
+}
+
+func buildModel(t *testing.T, spec []byte) *v3high.Document {
+	t.Helper()
+
+	doc, err := libopenapi.NewDocumentWithConfiguration(spec, &datamodel.DocumentConfiguration{
+		SkipCircularReferenceCheck: true,
+	})
+	require.NoError(t, err)
+
+	model, errs := doc.BuildV3Model()
+	require.Nil(t, errs)
+	return &model.Model
+}
+
+func uploadOperation(t *testing.T, contentType, bodySchema string) *v3high.Operation {
+	t.Helper()
+
+	model := buildModel(t, []byte(uploadSpec(contentType, bodySchema)))
+	return model.Paths.PathItems.GetOrZero("/upload").Post
+}
+
+func multipartSchema(t *testing.T, spec []byte) *base.SchemaProxy {
+	t.Helper()
+
+	model := buildModel(t, spec)
+	return model.Paths.PathItems.GetOrZero("/upload").Post.
+		RequestBody.Content.GetOrZero("multipart/form-data").Schema
+}

--- a/cmd/api/service.go
+++ b/cmd/api/service.go
@@ -317,7 +317,12 @@ func GenerateService(opts ServiceOptions) error {
 	}
 
 	// Step 1: Generate code with oapi-codegen
-	generatedCode, err := codegen.Generate(specContents, cfg)
+	genSpec, err := inlineMultipartBodies(specContents)
+	if err != nil {
+		return err
+	}
+
+	generatedCode, err := codegen.Generate(genSpec, cfg)
 	if err != nil {
 		return fmt.Errorf("oapi-codegen generate: %w", err)
 	}

--- a/cmd/api/service_test.go
+++ b/cmd/api/service_test.go
@@ -5,11 +5,52 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGenerateServiceBindsMultipartBody(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, GenerateService(ServiceOptions{
+		Name:      "multipart",
+		OutputDir: dir,
+		SpecPath:  filepath.Join("testdata", "multipart_body.yml"),
+		Quiet:     true,
+	}))
+
+	gen, err := os.ReadFile(filepath.Join(dir, "multipart", "gen.go"))
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name    string
+		handler string
+	}{
+		{"inline properties", "UploadInline"},
+		{"referenced schema", "UploadReferenced"},
+		{"allOf-composed schema", "UploadComposed"},
+		{"allOf-wrapped reference", "UploadWrapped"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := multipartHandlerBody(t, string(gen), tc.handler)
+			assert.Contains(t, body, "body.Kind", "form value is never bound to the body struct")
+			assert.Contains(t, body, "body.File", "uploaded file is never bound to the body struct")
+		})
+	}
+}
+
+// multipartHandlerBody returns the generated adapter method for handler, from
+// ParseMultipartForm to the point the body is handed to the service.
+func multipartHandlerBody(t *testing.T, gen, handler string) string {
+	t.Helper()
+
+	re := regexp.MustCompile(`(?s)OperationID: "` + handler + `".*?opts\.Body = &body`)
+	match := re.FindString(gen)
+	require.NotEmpty(t, match, "no multipart adapter generated for %s", handler)
+	return match
+}
 
 func TestWriteCompressedSpec(t *testing.T) {
 	spec := []byte("openapi: 3.0.0\ninfo:\n  title: t\n  version: 1\npaths: {}\n")

--- a/cmd/api/testdata/multipart_body.yml
+++ b/cmd/api/testdata/multipart_body.yml
@@ -1,0 +1,85 @@
+openapi: 3.0.3
+info:
+  title: multipart body binding
+  version: "1"
+paths:
+  /inline:
+    post:
+      operationId: upload_inline
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                kind:
+                  type: string
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: created
+  /referenced:
+    post:
+      operationId: upload_referenced
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/flat_uploader'
+      responses:
+        "201":
+          description: created
+  /composed:
+    post:
+      operationId: upload_composed
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/composed_uploader'
+      responses:
+        "201":
+          description: created
+  /wrapped:
+    post:
+      operationId: upload_wrapped
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/flat_uploader'
+      responses:
+        "201":
+          description: created
+components:
+  schemas:
+    flat_uploader:
+      type: object
+      properties:
+        kind:
+          type: string
+        file:
+          type: string
+          format: binary
+    uploader_shared:
+      type: object
+      properties:
+        kind:
+          type: string
+    uploader_request:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+    composed_uploader:
+      allOf:
+        - $ref: '#/components/schemas/uploader_shared'
+        - $ref: '#/components/schemas/uploader_request'


### PR DESCRIPTION
A file upload arrived at the handler as an empty struct whenever the operation named its body through a reference rather than spelling the properties out inline.
The form was parsed and then thrown away, so the handler filed the upload against nothing.

Such a body is now flattened to the equivalent inline object before generation, which is the shape the binding is emitted from.

- A multipart operation whose request body is a `$ref`, an `allOf`, or a reference to one produced a handler that parsed the form and handed over a zero-valued body. Every field of the upload, including the file itself, was silently lost.
- Only bodies written with inline properties worked, which is the minority style: most published specs name a shared uploader schema, so the endpoint most integrations are built around was the one that broke.
- Nothing failed loudly. The request was accepted, the handler ran, and the upload simply was not there, which surfaces later as a missing document rather than an error anyone can trace back.
- Such bodies are now flattened to the object they describe, merging composed members and their required fields, before the service is generated. Specs that never had the problem are passed through untouched.
