### PR TITLE
Skip the request cache when history is off

### DIFF
--- a/pkg/middleware/cache_read.go
+++ b/pkg/middleware/cache_read.go
@@ -16,8 +16,9 @@ func CreateCacheReadMiddleware(params *Params) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Check if it is GET request
-			if req.Method != http.MethodGet || !cfg.Cache.Requests {
+			// The cache is the history table, so recording off means nothing can
+			// populate it and the lookup is a guaranteed miss on the request path.
+			if req.Method != http.MethodGet || !cfg.Cache.Requests || !cfg.HistoryEnabled() {
 				next.ServeHTTP(w, req)
 				return
 			}

--- a/pkg/middleware/cache_read_test.go
+++ b/pkg/middleware/cache_read_test.go
@@ -126,6 +126,39 @@ func TestCreateCacheReadMiddleware(t *testing.T) {
 		assert.Equal("fresh", string(w.buf))
 	})
 
+	t.Run("history off ignores a populated cache", func(t *testing.T) {
+		disabled := false
+		params := newTestParams(&config.ServiceConfig{
+			Name: "foo",
+			Cache: &config.CacheConfig{
+				Requests: true,
+			},
+			History: &config.HistoryConfig{
+				Enabled: &disabled,
+			},
+		})
+
+		resp := &db.HistoryResponse{
+			Body:        []byte("cached"),
+			StatusCode:  http.StatusOK,
+			ContentType: "application/json",
+		}
+		params.DB().History().Set(context.Background(), "/foo/bar", &db.HistoryRequest{
+			Method: http.MethodGet,
+			URL:    "/foo/bar",
+		}, resp)
+
+		mw := CreateCacheReadMiddleware(params)
+		assert.NotNil(mw)
+
+		w := NewBufferedResponseWriter()
+		req := httptest.NewRequest(http.MethodGet, "/foo/bar", nil)
+
+		mw(handler).ServeHTTP(w, req)
+
+		assert.Equal("fresh", string(w.buf))
+	})
+
 	t.Run("restores content-type from cache", func(t *testing.T) {
 		params := newTestParams(&config.ServiceConfig{
 			Name: "service",


### PR DESCRIPTION
`CreateCacheReadMiddleware` serves the GET cache out of the history table, but it only gates on `cache.requests`:

```go
if req.Method != http.MethodGet || !cfg.Cache.Requests {
```

`cache.requests` defaults to true (`pkg/config/service.go:692`). With `history.enabled: false`, `cache_write` stops writing and the upstream paths are gated too, so nothing populates the table. Every GET then paid a `History().Get()` that could not hit. On the DynamoDB driver that is one `GetItem` per GET on the request path, since `GetByID` never runs on a miss.

Adds `!cfg.HistoryEnabled()` to the same early return.

One behavior change worth naming: a row written before recording was turned off is no longer served from cache until its TTL expires. That looks right rather than wrong. A disabled history should not still be answering requests.

Tests: new `history off ignores a populated cache` subtest in `cache_read_test.go`, which seeds the cache directly, disables history in the service config, and asserts the handler runs. Verified it fails on the old code (`-fresh +cached`) and passes on the new. Full `make test` and `make lint` green.