### PR TITLE
Keep reserved files out of spec discovery

### DIFF
--- a/internal/portable/resolve.go
+++ b/internal/portable/resolve.go
@@ -470,10 +470,6 @@ func writeTempSpec(name string, body []byte) (string, error) {
 	return path, nil
 }
 
-// findAllSpecsInDir returns every top-level non-reserved spec file in the dir,
-// sorted alphabetically. Reserved names (config.yml, context.yml, app.yml,
-// `index.<ext>`) are excluded.
-
 // inferServiceName picks a name for a single-folder invocation. In order:
 //  1. The `name:` field of a top-level config.yml.
 //  2. The basename of a single non-generic spec file (anything but `openapi.*`).
@@ -530,6 +526,10 @@ func readConfigName(dir string) string {
 	return probe.Name
 }
 
+// findAllSpecsInDir returns every top-level non-reserved spec file in the dir,
+// sorted alphabetically. Reserved names (config, context, app, codegen, index)
+// are excluded in every spec extension, so `codegen.yaml` is skipped the same
+// way `codegen.yml` is.
 func findAllSpecsInDir(dir string) []string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -542,11 +542,7 @@ func findAllSpecsInDir(dir string) []string {
 			continue
 		}
 		name := e.Name()
-		if name == configFile || name == contextFile || name == appFile {
-			continue
-		}
-		stem := strings.TrimSuffix(name, filepath.Ext(name))
-		if stem == "index" {
+		if isReservedName(name) {
 			continue
 		}
 		if !isSpecFile(name) {
@@ -557,6 +553,18 @@ func findAllSpecsInDir(dir string) []string {
 
 	sort.Strings(candidates)
 	return candidates
+}
+
+// isReservedName reports whether a file is one the loader owns rather than a
+// spec to serve. Matched on the stem, because every reserved name is also a
+// legal spec extension: a `codegen.yaml` next to an `openapi.yml` would
+// otherwise sort first and be served as the spec.
+func isReservedName(name string) bool {
+	switch strings.TrimSuffix(name, filepath.Ext(name)) {
+	case "config", "context", "app", "codegen", "index":
+		return true
+	}
+	return false
 }
 
 // findSpecInDir returns the path to a single canonical OpenAPI spec

--- a/internal/portable/resolve_test.go
+++ b/internal/portable/resolve_test.go
@@ -69,6 +69,30 @@ func TestFindSpecInDir(t *testing.T) {
 		assert.Equal(t, filepath.Join(dir, "stripe.yml"), findSpecInDir(dir))
 	})
 
+	t.Run("skips codegen.yml, which sorts before openapi.yml", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "codegen.yml"), []byte("filter:\n  include:\n    paths:\n      - /v1/customers"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yml"), []byte("openapi: 3.0.0"), 0o644))
+
+		assert.Equal(t, filepath.Join(dir, "openapi.yml"), findSpecInDir(dir))
+	})
+
+	t.Run("codegen.yml alone is not a spec", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "codegen.yml"), []byte("filter: {}"), 0o644))
+		assert.Empty(t, findSpecInDir(dir))
+	})
+
+	t.Run("reserved names are skipped in every spec extension", func(t *testing.T) {
+		for _, name := range []string{"codegen.yaml", "config.yaml", "context.yaml", "app.yaml", "index.yaml"} {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("x: 1"), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yml"), []byte("openapi: 3.0.0"), 0o644))
+
+			assert.Equal(t, filepath.Join(dir, "openapi.yml"), findSpecInDir(dir), name)
+		}
+	})
+
 	t.Run("picks alphabetically first of multiple candidates", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "z-other.yml"), []byte("openapi: 3.0.0"), 0o644))

--- a/internal/portable/watcher.go
+++ b/internal/portable/watcher.go
@@ -188,7 +188,7 @@ func matchServices(eventPath string, dirToServices map[string][]string) []string
 	base := filepath.Base(eventPath)
 	// Shared signals apply to every service sharing the dir. Checked
 	// before isSpecFile because context.yml/config.yml are also `.yml`.
-	if base == configFile || base == contextFile {
+	if isReservedName(base) {
 		return candidates
 	}
 


### PR DESCRIPTION
A service folder treated every YAML and JSON file as a possible spec and served the alphabetically first one. 
A `codegen.yml` sitting next to an `openapi.yml` therefore won on the letter c, failed to parse, and took the whole service down with it.

Reserved names are now matched on the stem, so every spelling of config, context, app, codegen and index is skipped rather than served.