### PR TITLE
Regenerate rather than serve a clipped cached body

### DIFF
--- a/docs/config/service.md
+++ b/docs/config/service.md
@@ -222,6 +222,15 @@ cache:
 
 Cached responses are returned for identical GET requests, improving performance.
 
+The cache is the history table rather than a store of its own, so it needs
+`history.enabled` too. With history off nothing records a response, and every
+lookup is a miss.
+
+That also ties the cache to whatever a storage backend keeps. A backend may cap
+the size of a stored body, and a response above its cap is never served from
+the cache: it is regenerated on every request instead. Check your backend's
+configuration if large responses are not being cached.
+
 ## Replay
 
 Record and replay API responses based on request fields. See [Replay](../replay.md) for full documentation.

--- a/pkg/middleware/cache_read.go
+++ b/pkg/middleware/cache_read.go
@@ -29,6 +29,17 @@ func CreateCacheReadMiddleware(params *Params) func(http.Handler) http.Handler {
 				return
 			}
 
+			// A record the storage backend clipped to fit its body cap is still
+			// good enough for the history UI, which badges it, but replaying one
+			// as a response hands the client truncated JSON under a 200. Serve
+			// the miss and regenerate instead.
+			if res.Response != nil && res.Response.IsBodyTruncated {
+				RequestLog(log, req).Debug("Cache hit ignored: stored body was truncated",
+					"path", req.URL.Path)
+				next.ServeHTTP(w, req)
+				return
+			}
+
 			RequestLog(log, req).Info("Cache hit", "path", req.URL.Path)
 
 			response := res.Response

--- a/pkg/middleware/cache_read_test.go
+++ b/pkg/middleware/cache_read_test.go
@@ -95,6 +95,25 @@ func TestCreateCacheReadMiddleware(t *testing.T) {
 
 			assert.Equal("cached", string(w.buf))
 		})
+
+		t.Run("get-truncated regenerates rather than serving a clipped body", func(t *testing.T) {
+			params.DB().History().Set(context.Background(), "/foo/big", &db.HistoryRequest{
+				Method: http.MethodGet,
+				URL:    "/foo/big",
+			}, &db.HistoryResponse{
+				Body:            []byte("clipped"),
+				StatusCode:      http.StatusOK,
+				ContentType:     "application/json",
+				IsBodyTruncated: true,
+			})
+
+			w := NewBufferedResponseWriter()
+			req := httptest.NewRequest(http.MethodGet, "/foo/big", nil)
+
+			mw(handler).ServeHTTP(w, req)
+
+			assert.Equal("fresh", string(w.buf))
+		})
 	})
 
 	t.Run("off", func(t *testing.T) {


### PR DESCRIPTION
The request cache is the history table, and history writes clip a body to the storage backend's cap. 
A cached GET over that cap was replayed to the client verbatim, so the response arrived cut off mid-JSON under a 200.

A record marked truncated is now treated as a miss.