### PR TITLE
Keep reserved files out of the packed manifest

### DIFF
--- a/internal/files/spec.go
+++ b/internal/files/spec.go
@@ -1,0 +1,59 @@
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SpecExts are the file extensions an OpenAPI spec may carry.
+var SpecExts = []string{".yml", ".yaml", ".json"}
+
+// FindSpecs returns every top-level non-reserved spec file in dir, sorted.
+// The packer shares it with the loader deliberately: the manifest it writes is
+// what the runtime registers from, so the two picking different files fails
+// silently.
+func FindSpecs(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var candidates []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if IsReservedName(name) || !IsSpec(name) {
+			continue
+		}
+		candidates = append(candidates, filepath.Join(dir, name))
+	}
+
+	sort.Strings(candidates)
+	return candidates
+}
+
+// IsSpec reports whether name carries a spec extension.
+func IsSpec(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	for _, e := range SpecExts {
+		if ext == e {
+			return true
+		}
+	}
+	return false
+}
+
+// IsReservedName reports whether name belongs to the tooling rather than being
+// a spec to serve. Matched on the stem, because every reserved name is also a
+// legal spec extension.
+func IsReservedName(name string) bool {
+	switch strings.TrimSuffix(name, filepath.Ext(name)) {
+	case "config", "context", "app", "codegen", "index":
+		return true
+	}
+	return false
+}

--- a/internal/files/spec_test.go
+++ b/internal/files/spec_test.go
@@ -1,0 +1,70 @@
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSpecFile(t *testing.T) {
+	for _, name := range []string{"petstore.yaml", "petstore.yml", "petstore.json", "PETSTORE.YML"} {
+		assert.True(t, IsSpec(name), name)
+	}
+	for _, name := range []string{"petstore.go", "petstore.txt", "petstore"} {
+		assert.False(t, IsSpec(name), name)
+	}
+}
+
+func TestIsReservedName(t *testing.T) {
+	t.Run("every reserved stem, in every spec extension", func(t *testing.T) {
+		for _, stem := range []string{"config", "context", "app", "codegen", "index"} {
+			for _, ext := range SpecExts {
+				assert.True(t, IsReservedName(stem+ext), stem+ext)
+			}
+		}
+	})
+
+	t.Run("a spec is not reserved", func(t *testing.T) {
+		for _, name := range []string{"openapi.yml", "stripe.yaml", "petstore.json"} {
+			assert.False(t, IsReservedName(name), name)
+		}
+	})
+}
+
+func TestFindSpecs(t *testing.T) {
+	write := func(t *testing.T, dir, name string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("openapi: 3.0.0"), 0o644))
+	}
+
+	t.Run("a reserved file never wins on sort order", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, dir, "codegen.yml")
+		write(t, dir, "openapi.yml")
+
+		assert.Equal(t, []string{filepath.Join(dir, "openapi.yml")}, FindSpecs(dir))
+	})
+
+	t.Run("subdirectories are ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "setup"), 0o755))
+		write(t, dir, filepath.Join("setup", "codegen.yml"))
+		write(t, dir, "openapi.yml")
+
+		assert.Equal(t, []string{filepath.Join(dir, "openapi.yml")}, FindSpecs(dir))
+	})
+
+	t.Run("candidates come back sorted", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, dir, "z-other.yml")
+		write(t, dir, "a-first.yml")
+
+		assert.Equal(t, []string{
+			filepath.Join(dir, "a-first.yml"),
+			filepath.Join(dir, "z-other.yml"),
+		}, FindSpecs(dir))
+	})
+}

--- a/internal/portable/resolve.go
+++ b/internal/portable/resolve.go
@@ -11,12 +11,13 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	cmdapi "github.com/mockzilla/mockzilla/v2/cmd/api"
 	"github.com/mockzilla/mockzilla/v2/pkg/pack"
 	"go.yaml.in/yaml/v4"
+
+	"github.com/mockzilla/mockzilla/v2/internal/files"
 )
 
 // Service is one discovered unit of work for portable mode. The folder name is
@@ -35,14 +36,12 @@ const (
 	servicesDir = "services"
 )
 
-var specExts = []string{".yml", ".yaml", ".json"}
-
 // isPortableArg returns true if arg looks like something portable mode
 // can serve: a spec, a URL, a package, a recognised directory shape,
 // or any single static-content file (.json/.html/.txt/.xml/.yml/...)
 // that we can fall back to serving at `GET /`.
 func isPortableArg(arg string) bool {
-	if isURL(arg) || isSpecFile(arg) || isPackageFile(arg) {
+	if isURL(arg) || files.IsSpec(arg) || isPackageFile(arg) {
 		return true
 	}
 
@@ -137,7 +136,7 @@ func resolveOne(arg string) ([]Service, error) {
 		return resolveDir(dir)
 	}
 
-	if isSpecFile(arg) {
+	if files.IsSpec(arg) {
 		data, err := os.ReadFile(arg)
 		if err != nil {
 			return nil, fmt.Errorf("reading %s: %w", arg, err)
@@ -183,7 +182,7 @@ func resolveDir(dir string) ([]Service, error) {
 	}
 
 	hasConfigFile := fileExists(filepath.Join(dir, configFile))
-	specs := findAllSpecsInDir(dir)
+	specs := files.FindSpecs(dir)
 
 	if isImplicitServicesRoot(dir, hasConfigFile, specs) {
 		return resolveServicesRoot(dir)
@@ -486,7 +485,7 @@ func inferServiceName(dir string, hasConfigFile bool) string {
 			return name
 		}
 	}
-	for _, spec := range findAllSpecsInDir(dir) {
+	for _, spec := range files.FindSpecs(dir) {
 		base := filepath.Base(spec)
 		stem := strings.TrimSuffix(base, filepath.Ext(base))
 		if strings.EqualFold(stem, "openapi") {
@@ -526,53 +525,12 @@ func readConfigName(dir string) string {
 	return probe.Name
 }
 
-// findAllSpecsInDir returns every top-level non-reserved spec file in the dir,
-// sorted alphabetically. Reserved names (config, context, app, codegen, index)
-// are excluded in every spec extension, so `codegen.yaml` is skipped the same
-// way `codegen.yml` is.
-func findAllSpecsInDir(dir string) []string {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	var candidates []string
-
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if isReservedName(name) {
-			continue
-		}
-		if !isSpecFile(name) {
-			continue
-		}
-		candidates = append(candidates, filepath.Join(dir, name))
-	}
-
-	sort.Strings(candidates)
-	return candidates
-}
-
-// isReservedName reports whether a file is one the loader owns rather than a
-// spec to serve. Matched on the stem, because every reserved name is also a
-// legal spec extension: a `codegen.yaml` next to an `openapi.yml` would
-// otherwise sort first and be served as the spec.
-func isReservedName(name string) bool {
-	switch strings.TrimSuffix(name, filepath.Ext(name)) {
-	case "config", "context", "app", "codegen", "index":
-		return true
-	}
-	return false
-}
-
 // findSpecInDir returns the path to a single canonical OpenAPI spec
 // inside a service folder, or empty string if none is present. When
 // multiple candidates exist, the alphabetically first one wins and
 // the others are logged so the user can disambiguate.
 func findSpecInDir(dir string) string {
-	candidates := findAllSpecsInDir(dir)
+	candidates := files.FindSpecs(dir)
 	if len(candidates) == 0 {
 		return ""
 	}
@@ -587,16 +545,6 @@ func findSpecInDir(dir string) string {
 func dirHasServicesRoot(dir string) bool {
 	info, err := os.Stat(filepath.Join(dir, servicesDir))
 	return err == nil && info.IsDir()
-}
-
-func isSpecFile(name string) bool {
-	ext := strings.ToLower(filepath.Ext(name))
-	for _, e := range specExts {
-		if ext == e {
-			return true
-		}
-	}
-	return false
 }
 
 func isPackageFile(name string) bool {
@@ -614,7 +562,7 @@ func fileExists(path string) bool {
 
 func serviceNameFromFile(path string) string {
 	base := filepath.Base(path)
-	for _, ext := range specExts {
+	for _, ext := range files.SpecExts {
 		if strings.HasSuffix(strings.ToLower(base), ext) {
 			return strings.TrimSuffix(base, base[len(base)-len(ext):])
 		}
@@ -675,7 +623,7 @@ func downloadSpec(rawURL string) (string, error) {
 	if name == "" || name == "." || name == "/" {
 		name = parsed.Host
 	}
-	if !isSpecFile(name) {
+	if !files.IsSpec(name) {
 		name += ".yml"
 	}
 
@@ -818,7 +766,7 @@ func specNameFromURL(parsed *url.URL) string {
 	if name == "" || name == "." || name == "/" {
 		name = parsed.Host
 	}
-	if !isSpecFile(name) {
+	if !files.IsSpec(name) {
 		name += ".yml"
 	}
 	return name

--- a/internal/portable/resolve_test.go
+++ b/internal/portable/resolve_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mockzilla/mockzilla/v2/internal/files"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,12 +23,12 @@ func TestIsURL(t *testing.T) {
 }
 
 func TestIsSpecFile(t *testing.T) {
-	assert.True(t, isSpecFile("petstore.yaml"))
-	assert.True(t, isSpecFile("petstore.yml"))
-	assert.True(t, isSpecFile("petstore.json"))
-	assert.False(t, isSpecFile("petstore.go"))
-	assert.False(t, isSpecFile("petstore.txt"))
-	assert.False(t, isSpecFile("petstore"))
+	assert.True(t, files.IsSpec("petstore.yaml"))
+	assert.True(t, files.IsSpec("petstore.yml"))
+	assert.True(t, files.IsSpec("petstore.json"))
+	assert.False(t, files.IsSpec("petstore.go"))
+	assert.False(t, files.IsSpec("petstore.txt"))
+	assert.False(t, files.IsSpec("petstore"))
 }
 
 func TestIsPackageFile(t *testing.T) {
@@ -641,7 +642,7 @@ func TestDownloadSpec(t *testing.T) {
 
 		path, err := downloadSpec(srv.URL + "/v2/api-docs")
 		require.NoError(t, err)
-		assert.True(t, isSpecFile(path))
+		assert.True(t, files.IsSpec(path))
 	})
 
 	t.Run("errors on HTTP failure", func(t *testing.T) {

--- a/internal/portable/watcher.go
+++ b/internal/portable/watcher.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/mockzilla/mockzilla/v2/internal/files"
 	"github.com/mockzilla/mockzilla/v2/pkg/api"
 	"github.com/mockzilla/mockzilla/v2/pkg/factory"
 	validator "github.com/pb33f/libopenapi-validator"
@@ -188,11 +189,11 @@ func matchServices(eventPath string, dirToServices map[string][]string) []string
 	base := filepath.Base(eventPath)
 	// Shared signals apply to every service sharing the dir. Checked
 	// before isSpecFile because context.yml/config.yml are also `.yml`.
-	if isReservedName(base) {
+	if files.IsReservedName(base) {
 		return candidates
 	}
 
-	if isSpecFile(base) {
+	if files.IsSpec(base) {
 		stem := serviceNameFromFile(base)
 		for _, n := range candidates {
 			if n == stem {
@@ -236,7 +237,7 @@ func isReloadEvent(event fsnotify.Event) bool {
 	if base == configFile || base == contextFile {
 		return true
 	}
-	if isSpecFile(base) {
+	if files.IsSpec(base) {
 		return true
 	}
 	// Any file with an extension inside the service folder might be a

--- a/pkg/pack/discover.go
+++ b/pkg/pack/discover.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	cmdapi "github.com/mockzilla/mockzilla/v2/cmd/api"
+	"github.com/mockzilla/mockzilla/v2/internal/files"
 )
 
 const (
@@ -16,8 +17,6 @@ const (
 	appFile     = "app.yml"
 	servicesDir = "services"
 )
-
-var specExts = []string{".yml", ".yaml", ".json"}
 
 // Discover walks srcDir and returns the service registry the manifest
 // should declare. The returned ServiceEntry paths are relative to
@@ -47,7 +46,7 @@ func Discover(srcDir string) ([]ServiceEntry, error) {
 	}
 
 	hasConfig := fileExists(filepath.Join(srcDir, configFile))
-	specs := findAllSpecsInDir(srcDir)
+	specs := files.FindSpecs(srcDir)
 
 	if isImplicitServicesRoot(srcDir, hasConfig, specs) {
 		return discoverServicesRoot(srcDir, srcDir)
@@ -310,7 +309,7 @@ func inferServiceName(dir string, hasConfigFile bool) string {
 			return name
 		}
 	}
-	for _, spec := range findAllSpecsInDir(dir) {
+	for _, spec := range files.FindSpecs(dir) {
 		base := filepath.Base(spec)
 		stem := strings.TrimSuffix(base, filepath.Ext(base))
 		if strings.EqualFold(stem, "openapi") {
@@ -342,61 +341,12 @@ func readConfigName(dir string) string {
 	return ""
 }
 
-func findAllSpecsInDir(dir string) []string {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	var candidates []string
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if isReservedName(name) {
-			continue
-		}
-		if !isSpecFile(name) {
-			continue
-		}
-		candidates = append(candidates, filepath.Join(dir, name))
-	}
-	sort.Strings(candidates)
-	return candidates
-}
-
 func findSpecInDir(dir string) string {
-	c := findAllSpecsInDir(dir)
+	c := files.FindSpecs(dir)
 	if len(c) == 0 {
 		return ""
 	}
 	return c[0]
-}
-
-// isReservedName reports whether a file is one the tooling owns rather than a
-// spec to serve. Matched on the stem, because every reserved name is also a
-// legal spec extension.
-//
-// This has to agree with the identical rule in internal/portable. The manifest
-// written here is what the runtime registers services from, so when the two
-// disagree a pack names one file as the spec and a live walk would name
-// another, and the runtime believes the manifest.
-func isReservedName(name string) bool {
-	switch strings.TrimSuffix(name, filepath.Ext(name)) {
-	case "config", "context", "app", "codegen", "index":
-		return true
-	}
-	return false
-}
-
-func isSpecFile(name string) bool {
-	ext := strings.ToLower(filepath.Ext(name))
-	for _, e := range specExts {
-		if ext == e {
-			return true
-		}
-	}
-	return false
 }
 
 func serviceNameFromFile(path string) string {

--- a/pkg/pack/discover.go
+++ b/pkg/pack/discover.go
@@ -353,11 +353,7 @@ func findAllSpecsInDir(dir string) []string {
 			continue
 		}
 		name := e.Name()
-		if name == configFile || name == contextFile || name == appFile {
-			continue
-		}
-		stem := strings.TrimSuffix(name, filepath.Ext(name))
-		if stem == "index" {
+		if isReservedName(name) {
 			continue
 		}
 		if !isSpecFile(name) {
@@ -375,6 +371,22 @@ func findSpecInDir(dir string) string {
 		return ""
 	}
 	return c[0]
+}
+
+// isReservedName reports whether a file is one the tooling owns rather than a
+// spec to serve. Matched on the stem, because every reserved name is also a
+// legal spec extension.
+//
+// This has to agree with the identical rule in internal/portable. The manifest
+// written here is what the runtime registers services from, so when the two
+// disagree a pack names one file as the spec and a live walk would name
+// another, and the runtime believes the manifest.
+func isReservedName(name string) bool {
+	switch strings.TrimSuffix(name, filepath.Ext(name)) {
+	case "config", "context", "app", "codegen", "index":
+		return true
+	}
+	return false
 }
 
 func isSpecFile(name string) bool {

--- a/pkg/pack/discover_test.go
+++ b/pkg/pack/discover_test.go
@@ -93,3 +93,34 @@ func TestIsImplicitServicesRoot(t *testing.T) {
 		assert.True(t, isImplicitServicesRoot(dir, false, nil))
 	})
 }
+
+func TestFindSpecInDir_ReservedNames(t *testing.T) {
+	write := func(t *testing.T, dir, name, body string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	}
+
+	t.Run("codegen.yml does not win over openapi.yml on sort order", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, dir, "codegen.yml", "filter:\n  include:\n    paths:\n      - /v1/customers")
+		write(t, dir, "openapi.yml", "openapi: 3.0.0")
+
+		assert.Equal(t, filepath.Join(dir, "openapi.yml"), findSpecInDir(dir))
+	})
+
+	t.Run("reserved names are skipped in every spec extension", func(t *testing.T) {
+		for _, name := range []string{"codegen.yaml", "config.yaml", "context.yaml", "app.yaml", "index.yaml"} {
+			dir := t.TempDir()
+			write(t, dir, name, "x: 1")
+			write(t, dir, "openapi.yml", "openapi: 3.0.0")
+
+			assert.Equal(t, filepath.Join(dir, "openapi.yml"), findSpecInDir(dir), name)
+		}
+	})
+
+	t.Run("a reserved file alone is not a spec", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, dir, "codegen.yml", "filter: {}")
+		assert.Empty(t, findSpecInDir(dir))
+	})
+}


### PR DESCRIPTION

## Summary
- A service folder holding both a `codegen.yml` and an `openapi.yml` packed into an archive whose manifest named the `codegen.yml` as the spec. On deploy the runtime read that manifest, tried to parse a filter file as an OpenAPI document, registered nothing, and every request to the simulation returned 404 with an empty service list.

- The loader already refuses to treat reserved files as specs, so the same folder served correctly when run directly. Only the packed path was wrong, which makes this hard to catch: it works locally and fails once deployed, and the archive is the only place the difference is visible.

- The manifest exists so the runtime does not have to re-walk the tree, which means it is authoritative. A newer runtime cannot correct a bad manifest, so shipping the loader fix alone did not help anything that goes through pack.

- Reserved names are matched on the stem here now, the same way the loader does it, so `codegen`, `config`, `context`, `app` and `index` are skipped in every spec extension.

