### PR TITLE
Write records before the response returns

### DIFF
--- a/pkg/middleware/cache.go
+++ b/pkg/middleware/cache.go
@@ -63,15 +63,13 @@ func cacheUpstreamResponse(params *Params, cfg *config.ServiceConfig, req *http.
 	key := cacheKey(req.Method, req.URL.String())
 	ttl := cacheTTL(cfg)
 	database := params.DB()
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), asyncWriteTimeout)
-		defer cancel()
+	safeWrite(params.Logger("cache"), func(ctx context.Context) {
 		writeCache(ctx, database, key, &cachedResponse{
 			Body:        body,
 			StatusCode:  status,
 			ContentType: contentType,
 		}, ttl)
-	}()
+	})
 }
 
 // cacheTTL returns how long a cached response stays valid. The request cache

--- a/pkg/middleware/cache_write.go
+++ b/pkg/middleware/cache_write.go
@@ -71,9 +71,7 @@ func CreateCacheWriteMiddleware(params *Params) func(http.Handler) http.Handler 
 
 				resourcePath := GetResourcePath(req)
 				key := cacheKey(req.Method, req.URL.String())
-				go func() {
-					ctx, cancel := context.WithTimeout(context.Background(), asyncWriteTimeout)
-					defer cancel()
+				safeWrite(params.Logger("cache-write"), func(ctx context.Context) {
 					if recordHistory {
 						params.DB().History().Set(ctx, resourcePath, histReq, histResp)
 					}
@@ -84,7 +82,7 @@ func CreateCacheWriteMiddleware(params *Params) func(http.Handler) http.Handler 
 							ContentType: respContentType,
 						}, cacheTTL(cfg))
 					}
-				}()
+				})
 			}
 
 			// Set our custom headers before writing

--- a/pkg/middleware/params.go
+++ b/pkg/middleware/params.go
@@ -4,15 +4,11 @@ import (
 	"bytes"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/mockzilla/mockzilla/v2/pkg/config"
 	"github.com/mockzilla/mockzilla/v2/pkg/db"
 )
-
-// asyncWriteTimeout is the maximum time allowed for background DB writes.
-const asyncWriteTimeout = 5 * time.Second
 
 // ResponseHeaderSource is the response header indicating where the response came from.
 const ResponseHeaderSource = "X-Mockzilla-Source"

--- a/pkg/middleware/replay_write.go
+++ b/pkg/middleware/replay_write.go
@@ -131,12 +131,10 @@ func CreateReplayWriteMiddleware(params *Params) func(http.Handler) http.Handler
 				CreatedAt:      time.Now(),
 			}
 
-			go func() {
-				ctx, cancel := context.WithTimeout(context.Background(), asyncWriteTimeout)
-				defer cancel()
+			safeWrite(log, func(ctx context.Context) {
 				table.Set(ctx, key, rec, ttl)
 				RequestLog(log, req).Info("Replay recorded", "method", req.Method, "path", req.URL.Path)
-			}()
+			})
 
 			writeThrough(w, rw)
 		})

--- a/pkg/middleware/upstream.go
+++ b/pkg/middleware/upstream.go
@@ -124,11 +124,9 @@ func CreateUpstreamRequestMiddleware(params *Params) func(http.Handler) http.Han
 						params.transformHistory(svcCfg, histReq, histResp)
 						resourcePath := GetResourcePath(req)
 
-						go func() {
-							ctx, cancel := context.WithTimeout(context.Background(), asyncWriteTimeout)
-							defer cancel()
+						safeWrite(log, func(ctx context.Context) {
 							params.DB().History().Set(ctx, resourcePath, histReq, histResp)
-						}()
+						})
 					}
 
 					SetRequestIDHeader(w, req)
@@ -254,11 +252,9 @@ func getUpstreamResponse(log *slog.Logger, svcCfg *config.ServiceConfig, cfg *co
 		}
 		params.transformHistory(svcCfg, histReq, histResp)
 		resourcePath := GetResourcePath(req)
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), asyncWriteTimeout)
-			defer cancel()
+		safeWrite(log, func(ctx context.Context) {
 			history.Set(ctx, resourcePath, histReq, histResp)
-		}()
+		})
 	}
 
 	return &upstreamResponse{

--- a/pkg/middleware/write.go
+++ b/pkg/middleware/write.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"time"
+)
+
+const writeTimeout = 500 * time.Millisecond
+
+// safeWrite records history, cache and replay entries. Losing one is preferable
+// to touching the response, so the deadline is short and a panic is contained.
+// Not for data a caller expects to survive.
+func safeWrite(log *slog.Logger, fn func(context.Context)) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Write failed", "err", r, "stack", string(debug.Stack()))
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
+	defer cancel()
+	fn(ctx)
+}

--- a/pkg/middleware/write_test.go
+++ b/pkg/middleware/write_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeWrite(t *testing.T) {
+	tests := []struct {
+		name         string
+		fn           func(*testing.T, context.Context)
+		wantPanicLog bool
+	}{
+		{
+			name: "Write receives a live context carrying the write deadline",
+			fn: func(t *testing.T, ctx context.Context) {
+				t.Helper()
+				deadline, ok := ctx.Deadline()
+				assert.True(t, ok)
+				assert.WithinDuration(t, time.Now().Add(writeTimeout), deadline, time.Second)
+				assert.NoError(t, ctx.Err())
+			},
+		},
+		{
+			name:         "Panicking driver is contained and logged",
+			fn:           func(*testing.T, context.Context) { panic("driver exploded") },
+			wantPanicLog: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var logged bytes.Buffer
+			log := slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelError}))
+
+			ran := false
+			assert.NotPanics(t, func() {
+				safeWrite(log, func(ctx context.Context) {
+					ran = true
+					tc.fn(t, ctx)
+				})
+			})
+
+			assert.True(t, ran)
+
+			if !tc.wantPanicLog {
+				assert.Empty(t, logged.String())
+				return
+			}
+
+			assert.Contains(t, logged.String(), "Write failed")
+			assert.Contains(t, logged.String(), "driver exploded")
+			assert.Contains(t, logged.String(), "stack=")
+		})
+	}
+}


### PR DESCRIPTION
A mocked request could return a perfectly good response and quietly lose its record. History entries, cached responses and replay records were written in the background once the response was already on its way, so anything that stopped the process at that moment dropped the write. Hosts that suspend a process between requests do exactly that, and for on-demand hosting it is normal, not a fault.

Records are now written before the response goes out, so a request that succeeds has its history, cache and replay entry. Upstream responses were affected by the same gap and are covered too.

The cost is bounded and lower than it was. A write gets 500ms, down from 5 seconds, and that is the most it can ever add to a response.

A storage backend that hangs or crashes can no longer take the response with it. A crash inside a background write used to stop the whole service, because nothing was there to catch it. It is now contained and logged, and the response is unaffected.
